### PR TITLE
🎛 Switch to using HTMLtoJSX

### DIFF
--- a/app/.eslintrc.yml
+++ b/app/.eslintrc.yml
@@ -1,0 +1,2 @@
+env:
+  browser: true

--- a/package.json
+++ b/package.json
@@ -31,14 +31,13 @@
     "doc-chomp": "1.1.0",
     "front-matter": "^2.1.0",
     "highlight.js": "^9.6.0",
+    "htmltojsx": "https://github.com/reactjs/react-magic#e63dabeefb87d4ce1e74ac2ddb73b0164c344219",
     "jsesc": "^2.2.0",
     "loader-utils": "^0.2.16",
     "markdown-it": "^8.1.0",
-    "markdown-it-regexp": "^0.4.0",
     "sha.js": "^2.4.5"
   },
   "devDependencies": {
-    "babel": "^6.5.2",
     "babel-cli": "^6.16.0",
     "babel-core": "^6.17.0",
     "babel-eslint": "^7.0.0",

--- a/src/__snapshots__/index.spec.js.snap
+++ b/src/__snapshots__/index.spec.js.snap
@@ -101,11 +101,12 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         _react2.default.createElement(\"br\", null),
-        \"  RUBY=blah\",
+        \"  \",
+        \"RUBY=blah\",
         _react2.default.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         _react2.default.createElement(\"br\", null)
       )
     ),
@@ -148,12 +149,13 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         _react2.default.createElement(\"br\", null),
-        \"  RUBY=\",
+        \"  \",
+        \"RUBY=\",
         props.rubycontent,
         _react2.default.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         _react2.default.createElement(\"br\", null)
       )
     ),
@@ -227,6 +229,7 @@ function MarkdownComponent(props) {
         ),
         \" buildkite-agent\",
         _react2.default.createElement(\"br\", null),
+        \"\\n\",
         _react2.default.createElement(
           \"span\",
           { className: \"hljs-function\" },
@@ -237,16 +240,17 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         _react2.default.createElement(\"br\", null),
-        \"  ENV=\",
+        \"  \",
+        \"ENV=\",
         _react2.default.createElement(
           \"span\",
           { className: \"hljs-string\" },
           \"\\\"foo_bar\\\"\"
         ),
         _react2.default.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         _react2.default.createElement(\"br\", null)
       )
     )
@@ -311,7 +315,8 @@ exports[`Webpack loader with a loader query of \`?\` for component example 0 ren
       () 
       {
       <br />
-        RUBY=blah
+        
+      RUBY=blah
       <br />
       }
       <br />
@@ -346,7 +351,8 @@ exports[`Webpack loader with a loader query of \`?\` for component example 0 ren
       () 
       {
       <br />
-        RUBY=
+        
+      RUBY=
       <br />
       }
       <br />
@@ -402,6 +408,8 @@ exports[`Webpack loader with a loader query of \`?\` for component example 0 ren
       </span>
        buildkite-agent
       <br />
+      
+      
       <span
         className="hljs-function">
         <span
@@ -412,7 +420,8 @@ exports[`Webpack loader with a loader query of \`?\` for component example 0 ren
       () 
       {
       <br />
-        ENV=
+        
+      ENV=
       <span
         className="hljs-string">
         \"foo_bar\"
@@ -450,23 +459,22 @@ function MarkdownComponent(props) {
       <p>This is a basic Markdown template, with no interpolations going on.</p>
       <p>This should be</p>
       <ul>
-      <li>easy and;</li>
-      <li>predictable!</li>
+        <li>easy and;</li>
+        <li>predictable!</li>
       </ul>
       <h2>Here\'s a code snippet with no interpolations</h2>
       <pre><code className=\"language-bash\">npm install -g yarn<br /></code></pre>
       <h2>Here\'s a code snippet with things which shouldn\'t be treated as interpolations</h2>
-      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br />  RUBY=blah<br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br />{\"  \"}RUBY=blah<br />{\"}\"}<br /></code></pre>
       <h2>Here\'s a paragraph with a simple interpolation</h2>
       <p>There are {Object.keys(props).length} props being supplied to this component.</p>
       <h2>Here\'s a code snippet with a simple interpolation</h2>
-      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br />  RUBY={props.rubycontent}<br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br />{\"  \"}RUBY={props.rubycontent}<br />{\"}\"}<br /></code></pre>
       <h2>Here\'s an unhinted code snippet</h2>
       <pre><code><span className=\"hljs-keyword\">the</span> quick brown fox jumps over <span className=\"hljs-keyword\">the</span> lazy dog<br /></code></pre>
       <h2>Here\'s an unhinted snippet with no discernible language</h2>
       <pre><code>)<span className=\"hljs-comment\">()</span><span className=\"hljs-comment\">(()</span>)<br /></code></pre>
-      <pre><code className=\"language-bash\">brew tap buildkite/buildkite<br />brew install --token=<span className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br />
-      <span className=\"hljs-function\"><span className=\"hljs-title\">function</span></span>() {\'{\'}<br />  ENV=<span className=\"hljs-string\">\"foo_bar\"</span><br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\">brew tap buildkite/buildkite<br />brew install --token=<span className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br />{\"\\n\"}<span className=\"hljs-function\"><span className=\"hljs-title\">function</span></span>() {\"{\"}<br />{\"  \"}ENV=<span className=\"hljs-string\">\"foo_bar\"</span><br />{\"}\"}<br /></code></pre>
     </div>
   );
 };
@@ -1015,11 +1023,12 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         React.createElement(\"br\", null),
-        \"  RUBY=blah\",
+        \"  \",
+        \"RUBY=blah\",
         React.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         React.createElement(\"br\", null)
       )
     ),
@@ -1062,12 +1071,13 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         React.createElement(\"br\", null),
-        \"  RUBY=\",
+        \"  \",
+        \"RUBY=\",
         props.rubycontent,
         React.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         React.createElement(\"br\", null)
       )
     ),
@@ -1141,6 +1151,7 @@ function MarkdownComponent(props) {
         ),
         \" buildkite-agent\",
         React.createElement(\"br\", null),
+        \"\\n\",
         React.createElement(
           \"span\",
           { className: \"hljs-function\" },
@@ -1151,16 +1162,17 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         React.createElement(\"br\", null),
-        \"  ENV=\",
+        \"  \",
+        \"ENV=\",
         React.createElement(
           \"span\",
           { className: \"hljs-string\" },
           \"\\\"foo_bar\\\"\"
         ),
         React.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         React.createElement(\"br\", null)
       )
     )
@@ -1225,7 +1237,8 @@ exports[`Webpack loader with a loader query of \`?implicitlyImportReact=false&pa
       () 
       {
       <br />
-        RUBY=blah
+        
+      RUBY=blah
       <br />
       }
       <br />
@@ -1260,7 +1273,8 @@ exports[`Webpack loader with a loader query of \`?implicitlyImportReact=false&pa
       () 
       {
       <br />
-        RUBY=
+        
+      RUBY=
       <br />
       }
       <br />
@@ -1316,6 +1330,8 @@ exports[`Webpack loader with a loader query of \`?implicitlyImportReact=false&pa
       </span>
        buildkite-agent
       <br />
+      
+      
       <span
         className="hljs-function">
         <span
@@ -1326,7 +1342,8 @@ exports[`Webpack loader with a loader query of \`?implicitlyImportReact=false&pa
       () 
       {
       <br />
-        ENV=
+        
+      ENV=
       <span
         className="hljs-string">
         \"foo_bar\"
@@ -1363,23 +1380,22 @@ function MarkdownComponent(props) {
       <p>This is a basic Markdown template, with no interpolations going on.</p>
       <p>This should be</p>
       <ul>
-      <li>easy and;</li>
-      <li>predictable!</li>
+        <li>easy and;</li>
+        <li>predictable!</li>
       </ul>
       <h2>Here\'s a code snippet with no interpolations</h2>
       <pre><code className=\"language-bash\">npm install -g yarn<br /></code></pre>
       <h2>Here\'s a code snippet with things which shouldn\'t be treated as interpolations</h2>
-      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br />  RUBY=blah<br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br />{\"  \"}RUBY=blah<br />{\"}\"}<br /></code></pre>
       <h2>Here\'s a paragraph with a simple interpolation</h2>
       <p>There are {Object.keys(props).length} props being supplied to this component.</p>
       <h2>Here\'s a code snippet with a simple interpolation</h2>
-      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br />  RUBY={props.rubycontent}<br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br />{\"  \"}RUBY={props.rubycontent}<br />{\"}\"}<br /></code></pre>
       <h2>Here\'s an unhinted code snippet</h2>
       <pre><code><span className=\"hljs-keyword\">the</span> quick brown fox jumps over <span className=\"hljs-keyword\">the</span> lazy dog<br /></code></pre>
       <h2>Here\'s an unhinted snippet with no discernible language</h2>
       <pre><code>)<span className=\"hljs-comment\">()</span><span className=\"hljs-comment\">(()</span>)<br /></code></pre>
-      <pre><code className=\"language-bash\">brew tap buildkite/buildkite<br />brew install --token=<span className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br />
-      <span className=\"hljs-function\"><span className=\"hljs-title\">function</span></span>() {\'{\'}<br />  ENV=<span className=\"hljs-string\">\"foo_bar\"</span><br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\">brew tap buildkite/buildkite<br />brew install --token=<span className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br />{\"\\n\"}<span className=\"hljs-function\"><span className=\"hljs-title\">function</span></span>() {\"{\"}<br />{\"  \"}ENV=<span className=\"hljs-string\">\"foo_bar\"</span><br />{\"}\"}<br /></code></pre>
     </div>
   );
 };
@@ -1911,11 +1927,12 @@ function MarkdownComponent(props) {
           )
         ),
         \'() \',
-        \'{\',
+        \"{\",
         React.createElement(\'br\', elementProps[\'br\']),
-        \'  RUBY=blah\',
+        \"  \",
+        \'RUBY=blah\',
         React.createElement(\'br\', elementProps[\'br\']),
-        \'}\',
+        \"}\",
         React.createElement(\'br\', elementProps[\'br\'])
       )
     ),
@@ -1958,12 +1975,13 @@ function MarkdownComponent(props) {
           )
         ),
         \'() \',
-        \'{\',
+        \"{\",
         React.createElement(\'br\', elementProps[\'br\']),
-        \'  RUBY=\',
+        \"  \",
+        \'RUBY=\',
         props.rubycontent,
         React.createElement(\'br\', elementProps[\'br\']),
-        \'}\',
+        \"}\",
         React.createElement(\'br\', elementProps[\'br\'])
       )
     ),
@@ -2037,6 +2055,7 @@ function MarkdownComponent(props) {
         ),
         \' buildkite-agent\',
         React.createElement(\'br\', elementProps[\'br\']),
+        \"\\n\",
         React.createElement(
           \'span\',
           _extends({}, elementProps[\'span\'], { className: \'hljs-function\' }),
@@ -2047,16 +2066,17 @@ function MarkdownComponent(props) {
           )
         ),
         \'() \',
-        \'{\',
+        \"{\",
         React.createElement(\'br\', elementProps[\'br\']),
-        \'  ENV=\',
+        \"  \",
+        \'ENV=\',
         React.createElement(
           \'span\',
           _extends({}, elementProps[\'span\'], { className: \'hljs-string\' }),
           \'\"foo_bar\"\'
         ),
         React.createElement(\'br\', elementProps[\'br\']),
-        \'}\',
+        \"}\",
         React.createElement(\'br\', elementProps[\'br\'])
       )
     )
@@ -2121,7 +2141,8 @@ exports[`Webpack loader with a loader query of \`?implicitlyImportReact=false&pa
       () 
       {
       <br />
-        RUBY=blah
+        
+      RUBY=blah
       <br />
       }
       <br />
@@ -2156,7 +2177,8 @@ exports[`Webpack loader with a loader query of \`?implicitlyImportReact=false&pa
       () 
       {
       <br />
-        RUBY=
+        
+      RUBY=
       <br />
       }
       <br />
@@ -2212,6 +2234,8 @@ exports[`Webpack loader with a loader query of \`?implicitlyImportReact=false&pa
       </span>
        buildkite-agent
       <br />
+      
+      
       <span
         className="hljs-function">
         <span
@@ -2222,7 +2246,8 @@ exports[`Webpack loader with a loader query of \`?implicitlyImportReact=false&pa
       () 
       {
       <br />
-        ENV=
+        
+      ENV=
       <span
         className="hljs-string">
         \"foo_bar\"
@@ -2265,23 +2290,22 @@ function MarkdownComponent(props) {
       <p {...elementProps[\'p\']}>This is a basic Markdown template, with no interpolations going on.</p>
       <p {...elementProps[\'p\']}>This should be</p>
       <ul {...elementProps[\'ul\']}>
-      <li {...elementProps[\'li\']}>easy and;</li>
-      <li {...elementProps[\'li\']}>predictable!</li>
+        <li {...elementProps[\'li\']}>easy and;</li>
+        <li {...elementProps[\'li\']}>predictable!</li>
       </ul>
       <h2 {...elementProps[\'h2\']}>Here\'s a code snippet with no interpolations</h2>
       <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\">npm install -g yarn<br {...elementProps[\'br\']} /></code></pre>
       <h2 {...elementProps[\'h2\']}>Here\'s a code snippet with things which shouldn\'t be treated as interpolations</h2>
-      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\"><span {...elementProps[\'span\']} className=\"hljs-keyword\">function</span> <span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br {...elementProps[\'br\']} />  RUBY=blah<br {...elementProps[\'br\']} />{\'}\'}<br {...elementProps[\'br\']} /></code></pre>
+      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\"><span {...elementProps[\'span\']} className=\"hljs-keyword\">function</span> <span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br {...elementProps[\'br\']} />{\"  \"}RUBY=blah<br {...elementProps[\'br\']} />{\"}\"}<br {...elementProps[\'br\']} /></code></pre>
       <h2 {...elementProps[\'h2\']}>Here\'s a paragraph with a simple interpolation</h2>
       <p {...elementProps[\'p\']}>There are {Object.keys(props).length} props being supplied to this component.</p>
       <h2 {...elementProps[\'h2\']}>Here\'s a code snippet with a simple interpolation</h2>
-      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\"><span {...elementProps[\'span\']} className=\"hljs-keyword\">function</span> <span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br {...elementProps[\'br\']} />  RUBY={props.rubycontent}<br {...elementProps[\'br\']} />{\'}\'}<br {...elementProps[\'br\']} /></code></pre>
+      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\"><span {...elementProps[\'span\']} className=\"hljs-keyword\">function</span> <span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br {...elementProps[\'br\']} />{\"  \"}RUBY={props.rubycontent}<br {...elementProps[\'br\']} />{\"}\"}<br {...elementProps[\'br\']} /></code></pre>
       <h2 {...elementProps[\'h2\']}>Here\'s an unhinted code snippet</h2>
       <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']}><span {...elementProps[\'span\']} className=\"hljs-keyword\">the</span> quick brown fox jumps over <span {...elementProps[\'span\']} className=\"hljs-keyword\">the</span> lazy dog<br {...elementProps[\'br\']} /></code></pre>
       <h2 {...elementProps[\'h2\']}>Here\'s an unhinted snippet with no discernible language</h2>
       <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']}>)<span {...elementProps[\'span\']} className=\"hljs-comment\">()</span><span {...elementProps[\'span\']} className=\"hljs-comment\">(()</span>)<br {...elementProps[\'br\']} /></code></pre>
-      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\">brew tap buildkite/buildkite<br {...elementProps[\'br\']} />brew install --token=<span {...elementProps[\'span\']} className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br {...elementProps[\'br\']} />
-      <span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">function</span></span>() {\'{\'}<br {...elementProps[\'br\']} />  ENV=<span {...elementProps[\'span\']} className=\"hljs-string\">\"foo_bar\"</span><br {...elementProps[\'br\']} />{\'}\'}<br {...elementProps[\'br\']} /></code></pre>
+      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\">brew tap buildkite/buildkite<br {...elementProps[\'br\']} />brew install --token=<span {...elementProps[\'span\']} className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br {...elementProps[\'br\']} />{\"\\n\"}<span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">function</span></span>() {\"{\"}<br {...elementProps[\'br\']} />{\"  \"}ENV=<span {...elementProps[\'span\']} className=\"hljs-string\">\"foo_bar\"</span><br {...elementProps[\'br\']} />{\"}\"}<br {...elementProps[\'br\']} /></code></pre>
     </div>
   );
 };
@@ -2852,11 +2876,12 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         React.createElement(\"br\", null),
-        \"  RUBY=blah\",
+        \"  \",
+        \"RUBY=blah\",
         React.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         React.createElement(\"br\", null)
       )
     ),
@@ -2899,12 +2924,13 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         React.createElement(\"br\", null),
-        \"  RUBY=\",
+        \"  \",
+        \"RUBY=\",
         props.rubycontent,
         React.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         React.createElement(\"br\", null)
       )
     ),
@@ -2978,6 +3004,7 @@ function MarkdownComponent(props) {
         ),
         \" buildkite-agent\",
         React.createElement(\"br\", null),
+        \"\\n\",
         React.createElement(
           \"span\",
           { className: \"hljs-function\" },
@@ -2988,16 +3015,17 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         React.createElement(\"br\", null),
-        \"  ENV=\",
+        \"  \",
+        \"ENV=\",
         React.createElement(
           \"span\",
           { className: \"hljs-string\" },
           \"\\\"foo_bar\\\"\"
         ),
         React.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         React.createElement(\"br\", null)
       )
     )
@@ -3062,7 +3090,8 @@ exports[`Webpack loader with a loader query of \`?implicitlyImportReact=false\` 
       () 
       {
       <br />
-        RUBY=blah
+        
+      RUBY=blah
       <br />
       }
       <br />
@@ -3097,7 +3126,8 @@ exports[`Webpack loader with a loader query of \`?implicitlyImportReact=false\` 
       () 
       {
       <br />
-        RUBY=
+        
+      RUBY=
       <br />
       }
       <br />
@@ -3153,6 +3183,8 @@ exports[`Webpack loader with a loader query of \`?implicitlyImportReact=false\` 
       </span>
        buildkite-agent
       <br />
+      
+      
       <span
         className="hljs-function">
         <span
@@ -3163,7 +3195,8 @@ exports[`Webpack loader with a loader query of \`?implicitlyImportReact=false\` 
       () 
       {
       <br />
-        ENV=
+        
+      ENV=
       <span
         className="hljs-string">
         \"foo_bar\"
@@ -3200,23 +3233,22 @@ function MarkdownComponent(props) {
       <p>This is a basic Markdown template, with no interpolations going on.</p>
       <p>This should be</p>
       <ul>
-      <li>easy and;</li>
-      <li>predictable!</li>
+        <li>easy and;</li>
+        <li>predictable!</li>
       </ul>
       <h2>Here\'s a code snippet with no interpolations</h2>
       <pre><code className=\"language-bash\">npm install -g yarn<br /></code></pre>
       <h2>Here\'s a code snippet with things which shouldn\'t be treated as interpolations</h2>
-      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br />  RUBY=blah<br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br />{\"  \"}RUBY=blah<br />{\"}\"}<br /></code></pre>
       <h2>Here\'s a paragraph with a simple interpolation</h2>
       <p>There are {Object.keys(props).length} props being supplied to this component.</p>
       <h2>Here\'s a code snippet with a simple interpolation</h2>
-      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br />  RUBY={props.rubycontent}<br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br />{\"  \"}RUBY={props.rubycontent}<br />{\"}\"}<br /></code></pre>
       <h2>Here\'s an unhinted code snippet</h2>
       <pre><code><span className=\"hljs-keyword\">the</span> quick brown fox jumps over <span className=\"hljs-keyword\">the</span> lazy dog<br /></code></pre>
       <h2>Here\'s an unhinted snippet with no discernible language</h2>
       <pre><code>)<span className=\"hljs-comment\">()</span><span className=\"hljs-comment\">(()</span>)<br /></code></pre>
-      <pre><code className=\"language-bash\">brew tap buildkite/buildkite<br />brew install --token=<span className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br />
-      <span className=\"hljs-function\"><span className=\"hljs-title\">function</span></span>() {\'{\'}<br />  ENV=<span className=\"hljs-string\">\"foo_bar\"</span><br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\">brew tap buildkite/buildkite<br />brew install --token=<span className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br />{\"\\n\"}<span className=\"hljs-function\"><span className=\"hljs-title\">function</span></span>() {\"{\"}<br />{\"  \"}ENV=<span className=\"hljs-string\">\"foo_bar\"</span><br />{\"}\"}<br /></code></pre>
     </div>
   );
 };
@@ -3745,11 +3777,12 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         _react2.default.createElement(\"br\", null),
-        \"  RUBY=blah\",
+        \"  \",
+        \"RUBY=blah\",
         _react2.default.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         _react2.default.createElement(\"br\", null)
       )
     ),
@@ -3792,12 +3825,13 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         _react2.default.createElement(\"br\", null),
-        \"  RUBY=\",
+        \"  \",
+        \"RUBY=\",
         props.rubycontent,
         _react2.default.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         _react2.default.createElement(\"br\", null)
       )
     ),
@@ -3871,6 +3905,7 @@ function MarkdownComponent(props) {
         ),
         \" buildkite-agent\",
         _react2.default.createElement(\"br\", null),
+        \"\\n\",
         _react2.default.createElement(
           \"span\",
           { className: \"hljs-function\" },
@@ -3881,16 +3916,17 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         _react2.default.createElement(\"br\", null),
-        \"  ENV=\",
+        \"  \",
+        \"ENV=\",
         _react2.default.createElement(
           \"span\",
           { className: \"hljs-string\" },
           \"\\\"foo_bar\\\"\"
         ),
         _react2.default.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         _react2.default.createElement(\"br\", null)
       )
     )
@@ -3955,7 +3991,8 @@ exports[`Webpack loader with a loader query of \`?implicitlyImportReact=true&pas
       () 
       {
       <br />
-        RUBY=blah
+        
+      RUBY=blah
       <br />
       }
       <br />
@@ -3990,7 +4027,8 @@ exports[`Webpack loader with a loader query of \`?implicitlyImportReact=true&pas
       () 
       {
       <br />
-        RUBY=
+        
+      RUBY=
       <br />
       }
       <br />
@@ -4046,6 +4084,8 @@ exports[`Webpack loader with a loader query of \`?implicitlyImportReact=true&pas
       </span>
        buildkite-agent
       <br />
+      
+      
       <span
         className="hljs-function">
         <span
@@ -4056,7 +4096,8 @@ exports[`Webpack loader with a loader query of \`?implicitlyImportReact=true&pas
       () 
       {
       <br />
-        ENV=
+        
+      ENV=
       <span
         className="hljs-string">
         \"foo_bar\"
@@ -4094,23 +4135,22 @@ function MarkdownComponent(props) {
       <p>This is a basic Markdown template, with no interpolations going on.</p>
       <p>This should be</p>
       <ul>
-      <li>easy and;</li>
-      <li>predictable!</li>
+        <li>easy and;</li>
+        <li>predictable!</li>
       </ul>
       <h2>Here\'s a code snippet with no interpolations</h2>
       <pre><code className=\"language-bash\">npm install -g yarn<br /></code></pre>
       <h2>Here\'s a code snippet with things which shouldn\'t be treated as interpolations</h2>
-      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br />  RUBY=blah<br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br />{\"  \"}RUBY=blah<br />{\"}\"}<br /></code></pre>
       <h2>Here\'s a paragraph with a simple interpolation</h2>
       <p>There are {Object.keys(props).length} props being supplied to this component.</p>
       <h2>Here\'s a code snippet with a simple interpolation</h2>
-      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br />  RUBY={props.rubycontent}<br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br />{\"  \"}RUBY={props.rubycontent}<br />{\"}\"}<br /></code></pre>
       <h2>Here\'s an unhinted code snippet</h2>
       <pre><code><span className=\"hljs-keyword\">the</span> quick brown fox jumps over <span className=\"hljs-keyword\">the</span> lazy dog<br /></code></pre>
       <h2>Here\'s an unhinted snippet with no discernible language</h2>
       <pre><code>)<span className=\"hljs-comment\">()</span><span className=\"hljs-comment\">(()</span>)<br /></code></pre>
-      <pre><code className=\"language-bash\">brew tap buildkite/buildkite<br />brew install --token=<span className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br />
-      <span className=\"hljs-function\"><span className=\"hljs-title\">function</span></span>() {\'{\'}<br />  ENV=<span className=\"hljs-string\">\"foo_bar\"</span><br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\">brew tap buildkite/buildkite<br />brew install --token=<span className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br />{\"\\n\"}<span className=\"hljs-function\"><span className=\"hljs-title\">function</span></span>() {\"{\"}<br />{\"  \"}ENV=<span className=\"hljs-string\">\"foo_bar\"</span><br />{\"}\"}<br /></code></pre>
     </div>
   );
 };
@@ -4673,11 +4713,12 @@ function MarkdownComponent(props) {
           )
         ),
         \'() \',
-        \'{\',
+        \"{\",
         _react2.default.createElement(\'br\', elementProps[\'br\']),
-        \'  RUBY=blah\',
+        \"  \",
+        \'RUBY=blah\',
         _react2.default.createElement(\'br\', elementProps[\'br\']),
-        \'}\',
+        \"}\",
         _react2.default.createElement(\'br\', elementProps[\'br\'])
       )
     ),
@@ -4720,12 +4761,13 @@ function MarkdownComponent(props) {
           )
         ),
         \'() \',
-        \'{\',
+        \"{\",
         _react2.default.createElement(\'br\', elementProps[\'br\']),
-        \'  RUBY=\',
+        \"  \",
+        \'RUBY=\',
         props.rubycontent,
         _react2.default.createElement(\'br\', elementProps[\'br\']),
-        \'}\',
+        \"}\",
         _react2.default.createElement(\'br\', elementProps[\'br\'])
       )
     ),
@@ -4799,6 +4841,7 @@ function MarkdownComponent(props) {
         ),
         \' buildkite-agent\',
         _react2.default.createElement(\'br\', elementProps[\'br\']),
+        \"\\n\",
         _react2.default.createElement(
           \'span\',
           _extends({}, elementProps[\'span\'], { className: \'hljs-function\' }),
@@ -4809,16 +4852,17 @@ function MarkdownComponent(props) {
           )
         ),
         \'() \',
-        \'{\',
+        \"{\",
         _react2.default.createElement(\'br\', elementProps[\'br\']),
-        \'  ENV=\',
+        \"  \",
+        \'ENV=\',
         _react2.default.createElement(
           \'span\',
           _extends({}, elementProps[\'span\'], { className: \'hljs-string\' }),
           \'\"foo_bar\"\'
         ),
         _react2.default.createElement(\'br\', elementProps[\'br\']),
-        \'}\',
+        \"}\",
         _react2.default.createElement(\'br\', elementProps[\'br\'])
       )
     )
@@ -4883,7 +4927,8 @@ exports[`Webpack loader with a loader query of \`?implicitlyImportReact=true&pas
       () 
       {
       <br />
-        RUBY=blah
+        
+      RUBY=blah
       <br />
       }
       <br />
@@ -4918,7 +4963,8 @@ exports[`Webpack loader with a loader query of \`?implicitlyImportReact=true&pas
       () 
       {
       <br />
-        RUBY=
+        
+      RUBY=
       <br />
       }
       <br />
@@ -4974,6 +5020,8 @@ exports[`Webpack loader with a loader query of \`?implicitlyImportReact=true&pas
       </span>
        buildkite-agent
       <br />
+      
+      
       <span
         className="hljs-function">
         <span
@@ -4984,7 +5032,8 @@ exports[`Webpack loader with a loader query of \`?implicitlyImportReact=true&pas
       () 
       {
       <br />
-        ENV=
+        
+      ENV=
       <span
         className="hljs-string">
         \"foo_bar\"
@@ -5028,23 +5077,22 @@ function MarkdownComponent(props) {
       <p {...elementProps[\'p\']}>This is a basic Markdown template, with no interpolations going on.</p>
       <p {...elementProps[\'p\']}>This should be</p>
       <ul {...elementProps[\'ul\']}>
-      <li {...elementProps[\'li\']}>easy and;</li>
-      <li {...elementProps[\'li\']}>predictable!</li>
+        <li {...elementProps[\'li\']}>easy and;</li>
+        <li {...elementProps[\'li\']}>predictable!</li>
       </ul>
       <h2 {...elementProps[\'h2\']}>Here\'s a code snippet with no interpolations</h2>
       <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\">npm install -g yarn<br {...elementProps[\'br\']} /></code></pre>
       <h2 {...elementProps[\'h2\']}>Here\'s a code snippet with things which shouldn\'t be treated as interpolations</h2>
-      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\"><span {...elementProps[\'span\']} className=\"hljs-keyword\">function</span> <span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br {...elementProps[\'br\']} />  RUBY=blah<br {...elementProps[\'br\']} />{\'}\'}<br {...elementProps[\'br\']} /></code></pre>
+      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\"><span {...elementProps[\'span\']} className=\"hljs-keyword\">function</span> <span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br {...elementProps[\'br\']} />{\"  \"}RUBY=blah<br {...elementProps[\'br\']} />{\"}\"}<br {...elementProps[\'br\']} /></code></pre>
       <h2 {...elementProps[\'h2\']}>Here\'s a paragraph with a simple interpolation</h2>
       <p {...elementProps[\'p\']}>There are {Object.keys(props).length} props being supplied to this component.</p>
       <h2 {...elementProps[\'h2\']}>Here\'s a code snippet with a simple interpolation</h2>
-      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\"><span {...elementProps[\'span\']} className=\"hljs-keyword\">function</span> <span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br {...elementProps[\'br\']} />  RUBY={props.rubycontent}<br {...elementProps[\'br\']} />{\'}\'}<br {...elementProps[\'br\']} /></code></pre>
+      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\"><span {...elementProps[\'span\']} className=\"hljs-keyword\">function</span> <span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br {...elementProps[\'br\']} />{\"  \"}RUBY={props.rubycontent}<br {...elementProps[\'br\']} />{\"}\"}<br {...elementProps[\'br\']} /></code></pre>
       <h2 {...elementProps[\'h2\']}>Here\'s an unhinted code snippet</h2>
       <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']}><span {...elementProps[\'span\']} className=\"hljs-keyword\">the</span> quick brown fox jumps over <span {...elementProps[\'span\']} className=\"hljs-keyword\">the</span> lazy dog<br {...elementProps[\'br\']} /></code></pre>
       <h2 {...elementProps[\'h2\']}>Here\'s an unhinted snippet with no discernible language</h2>
       <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']}>)<span {...elementProps[\'span\']} className=\"hljs-comment\">()</span><span {...elementProps[\'span\']} className=\"hljs-comment\">(()</span>)<br {...elementProps[\'br\']} /></code></pre>
-      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\">brew tap buildkite/buildkite<br {...elementProps[\'br\']} />brew install --token=<span {...elementProps[\'span\']} className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br {...elementProps[\'br\']} />
-      <span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">function</span></span>() {\'{\'}<br {...elementProps[\'br\']} />  ENV=<span {...elementProps[\'span\']} className=\"hljs-string\">\"foo_bar\"</span><br {...elementProps[\'br\']} />{\'}\'}<br {...elementProps[\'br\']} /></code></pre>
+      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\">brew tap buildkite/buildkite<br {...elementProps[\'br\']} />brew install --token=<span {...elementProps[\'span\']} className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br {...elementProps[\'br\']} />{\"\\n\"}<span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">function</span></span>() {\"{\"}<br {...elementProps[\'br\']} />{\"  \"}ENV=<span {...elementProps[\'span\']} className=\"hljs-string\">\"foo_bar\"</span><br {...elementProps[\'br\']} />{\"}\"}<br {...elementProps[\'br\']} /></code></pre>
     </div>
   );
 };
@@ -5647,11 +5695,12 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         _react2.default.createElement(\"br\", null),
-        \"  RUBY=blah\",
+        \"  \",
+        \"RUBY=blah\",
         _react2.default.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         _react2.default.createElement(\"br\", null)
       )
     ),
@@ -5694,12 +5743,13 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         _react2.default.createElement(\"br\", null),
-        \"  RUBY=\",
+        \"  \",
+        \"RUBY=\",
         props.rubycontent,
         _react2.default.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         _react2.default.createElement(\"br\", null)
       )
     ),
@@ -5773,6 +5823,7 @@ function MarkdownComponent(props) {
         ),
         \" buildkite-agent\",
         _react2.default.createElement(\"br\", null),
+        \"\\n\",
         _react2.default.createElement(
           \"span\",
           { className: \"hljs-function\" },
@@ -5783,16 +5834,17 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         _react2.default.createElement(\"br\", null),
-        \"  ENV=\",
+        \"  \",
+        \"ENV=\",
         _react2.default.createElement(
           \"span\",
           { className: \"hljs-string\" },
           \"\\\"foo_bar\\\"\"
         ),
         _react2.default.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         _react2.default.createElement(\"br\", null)
       )
     )
@@ -5857,7 +5909,8 @@ exports[`Webpack loader with a loader query of \`?implicitlyImportReact=true\` f
       () 
       {
       <br />
-        RUBY=blah
+        
+      RUBY=blah
       <br />
       }
       <br />
@@ -5892,7 +5945,8 @@ exports[`Webpack loader with a loader query of \`?implicitlyImportReact=true\` f
       () 
       {
       <br />
-        RUBY=
+        
+      RUBY=
       <br />
       }
       <br />
@@ -5948,6 +6002,8 @@ exports[`Webpack loader with a loader query of \`?implicitlyImportReact=true\` f
       </span>
        buildkite-agent
       <br />
+      
+      
       <span
         className="hljs-function">
         <span
@@ -5958,7 +6014,8 @@ exports[`Webpack loader with a loader query of \`?implicitlyImportReact=true\` f
       () 
       {
       <br />
-        ENV=
+        
+      ENV=
       <span
         className="hljs-string">
         \"foo_bar\"
@@ -5996,23 +6053,22 @@ function MarkdownComponent(props) {
       <p>This is a basic Markdown template, with no interpolations going on.</p>
       <p>This should be</p>
       <ul>
-      <li>easy and;</li>
-      <li>predictable!</li>
+        <li>easy and;</li>
+        <li>predictable!</li>
       </ul>
       <h2>Here\'s a code snippet with no interpolations</h2>
       <pre><code className=\"language-bash\">npm install -g yarn<br /></code></pre>
       <h2>Here\'s a code snippet with things which shouldn\'t be treated as interpolations</h2>
-      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br />  RUBY=blah<br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br />{\"  \"}RUBY=blah<br />{\"}\"}<br /></code></pre>
       <h2>Here\'s a paragraph with a simple interpolation</h2>
       <p>There are {Object.keys(props).length} props being supplied to this component.</p>
       <h2>Here\'s a code snippet with a simple interpolation</h2>
-      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br />  RUBY={props.rubycontent}<br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br />{\"  \"}RUBY={props.rubycontent}<br />{\"}\"}<br /></code></pre>
       <h2>Here\'s an unhinted code snippet</h2>
       <pre><code><span className=\"hljs-keyword\">the</span> quick brown fox jumps over <span className=\"hljs-keyword\">the</span> lazy dog<br /></code></pre>
       <h2>Here\'s an unhinted snippet with no discernible language</h2>
       <pre><code>)<span className=\"hljs-comment\">()</span><span className=\"hljs-comment\">(()</span>)<br /></code></pre>
-      <pre><code className=\"language-bash\">brew tap buildkite/buildkite<br />brew install --token=<span className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br />
-      <span className=\"hljs-function\"><span className=\"hljs-title\">function</span></span>() {\'{\'}<br />  ENV=<span className=\"hljs-string\">\"foo_bar\"</span><br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\">brew tap buildkite/buildkite<br />brew install --token=<span className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br />{\"\\n\"}<span className=\"hljs-function\"><span className=\"hljs-title\">function</span></span>() {\"{\"}<br />{\"  \"}ENV=<span className=\"hljs-string\">\"foo_bar\"</span><br />{\"}\"}<br /></code></pre>
     </div>
   );
 };
@@ -6567,11 +6623,12 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         _react2.default.createElement(\"br\", null),
-        \"  RUBY=blah\",
+        \"  \",
+        \"RUBY=blah\",
         _react2.default.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         _react2.default.createElement(\"br\", null)
       )
     ),
@@ -6614,12 +6671,13 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         _react2.default.createElement(\"br\", null),
-        \"  RUBY=\",
+        \"  \",
+        \"RUBY=\",
         props.rubycontent,
         _react2.default.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         _react2.default.createElement(\"br\", null)
       )
     ),
@@ -6693,6 +6751,7 @@ function MarkdownComponent(props) {
         ),
         \" buildkite-agent\",
         _react2.default.createElement(\"br\", null),
+        \"\\n\",
         _react2.default.createElement(
           \"span\",
           { className: \"hljs-function\" },
@@ -6703,16 +6762,17 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         _react2.default.createElement(\"br\", null),
-        \"  ENV=\",
+        \"  \",
+        \"ENV=\",
         _react2.default.createElement(
           \"span\",
           { className: \"hljs-string\" },
           \"\\\"foo_bar\\\"\"
         ),
         _react2.default.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         _react2.default.createElement(\"br\", null)
       )
     )
@@ -6777,7 +6837,8 @@ exports[`Webpack loader with a loader query of \`?passElementProps=false\` for c
       () 
       {
       <br />
-        RUBY=blah
+        
+      RUBY=blah
       <br />
       }
       <br />
@@ -6812,7 +6873,8 @@ exports[`Webpack loader with a loader query of \`?passElementProps=false\` for c
       () 
       {
       <br />
-        RUBY=
+        
+      RUBY=
       <br />
       }
       <br />
@@ -6868,6 +6930,8 @@ exports[`Webpack loader with a loader query of \`?passElementProps=false\` for c
       </span>
        buildkite-agent
       <br />
+      
+      
       <span
         className="hljs-function">
         <span
@@ -6878,7 +6942,8 @@ exports[`Webpack loader with a loader query of \`?passElementProps=false\` for c
       () 
       {
       <br />
-        ENV=
+        
+      ENV=
       <span
         className="hljs-string">
         \"foo_bar\"
@@ -6916,23 +6981,22 @@ function MarkdownComponent(props) {
       <p>This is a basic Markdown template, with no interpolations going on.</p>
       <p>This should be</p>
       <ul>
-      <li>easy and;</li>
-      <li>predictable!</li>
+        <li>easy and;</li>
+        <li>predictable!</li>
       </ul>
       <h2>Here\'s a code snippet with no interpolations</h2>
       <pre><code className=\"language-bash\">npm install -g yarn<br /></code></pre>
       <h2>Here\'s a code snippet with things which shouldn\'t be treated as interpolations</h2>
-      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br />  RUBY=blah<br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br />{\"  \"}RUBY=blah<br />{\"}\"}<br /></code></pre>
       <h2>Here\'s a paragraph with a simple interpolation</h2>
       <p>There are {Object.keys(props).length} props being supplied to this component.</p>
       <h2>Here\'s a code snippet with a simple interpolation</h2>
-      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br />  RUBY={props.rubycontent}<br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br />{\"  \"}RUBY={props.rubycontent}<br />{\"}\"}<br /></code></pre>
       <h2>Here\'s an unhinted code snippet</h2>
       <pre><code><span className=\"hljs-keyword\">the</span> quick brown fox jumps over <span className=\"hljs-keyword\">the</span> lazy dog<br /></code></pre>
       <h2>Here\'s an unhinted snippet with no discernible language</h2>
       <pre><code>)<span className=\"hljs-comment\">()</span><span className=\"hljs-comment\">(()</span>)<br /></code></pre>
-      <pre><code className=\"language-bash\">brew tap buildkite/buildkite<br />brew install --token=<span className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br />
-      <span className=\"hljs-function\"><span className=\"hljs-title\">function</span></span>() {\'{\'}<br />  ENV=<span className=\"hljs-string\">\"foo_bar\"</span><br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\">brew tap buildkite/buildkite<br />brew install --token=<span className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br />{\"\\n\"}<span className=\"hljs-function\"><span className=\"hljs-title\">function</span></span>() {\"{\"}<br />{\"  \"}ENV=<span className=\"hljs-string\">\"foo_bar\"</span><br />{\"}\"}<br /></code></pre>
     </div>
   );
 };
@@ -7495,11 +7559,12 @@ function MarkdownComponent(props) {
           )
         ),
         \'() \',
-        \'{\',
+        \"{\",
         _react2.default.createElement(\'br\', elementProps[\'br\']),
-        \'  RUBY=blah\',
+        \"  \",
+        \'RUBY=blah\',
         _react2.default.createElement(\'br\', elementProps[\'br\']),
-        \'}\',
+        \"}\",
         _react2.default.createElement(\'br\', elementProps[\'br\'])
       )
     ),
@@ -7542,12 +7607,13 @@ function MarkdownComponent(props) {
           )
         ),
         \'() \',
-        \'{\',
+        \"{\",
         _react2.default.createElement(\'br\', elementProps[\'br\']),
-        \'  RUBY=\',
+        \"  \",
+        \'RUBY=\',
         props.rubycontent,
         _react2.default.createElement(\'br\', elementProps[\'br\']),
-        \'}\',
+        \"}\",
         _react2.default.createElement(\'br\', elementProps[\'br\'])
       )
     ),
@@ -7621,6 +7687,7 @@ function MarkdownComponent(props) {
         ),
         \' buildkite-agent\',
         _react2.default.createElement(\'br\', elementProps[\'br\']),
+        \"\\n\",
         _react2.default.createElement(
           \'span\',
           _extends({}, elementProps[\'span\'], { className: \'hljs-function\' }),
@@ -7631,16 +7698,17 @@ function MarkdownComponent(props) {
           )
         ),
         \'() \',
-        \'{\',
+        \"{\",
         _react2.default.createElement(\'br\', elementProps[\'br\']),
-        \'  ENV=\',
+        \"  \",
+        \'ENV=\',
         _react2.default.createElement(
           \'span\',
           _extends({}, elementProps[\'span\'], { className: \'hljs-string\' }),
           \'\"foo_bar\"\'
         ),
         _react2.default.createElement(\'br\', elementProps[\'br\']),
-        \'}\',
+        \"}\",
         _react2.default.createElement(\'br\', elementProps[\'br\'])
       )
     )
@@ -7705,7 +7773,8 @@ exports[`Webpack loader with a loader query of \`?passElementProps=true\` for co
       () 
       {
       <br />
-        RUBY=blah
+        
+      RUBY=blah
       <br />
       }
       <br />
@@ -7740,7 +7809,8 @@ exports[`Webpack loader with a loader query of \`?passElementProps=true\` for co
       () 
       {
       <br />
-        RUBY=
+        
+      RUBY=
       <br />
       }
       <br />
@@ -7796,6 +7866,8 @@ exports[`Webpack loader with a loader query of \`?passElementProps=true\` for co
       </span>
        buildkite-agent
       <br />
+      
+      
       <span
         className="hljs-function">
         <span
@@ -7806,7 +7878,8 @@ exports[`Webpack loader with a loader query of \`?passElementProps=true\` for co
       () 
       {
       <br />
-        ENV=
+        
+      ENV=
       <span
         className="hljs-string">
         \"foo_bar\"
@@ -7850,23 +7923,22 @@ function MarkdownComponent(props) {
       <p {...elementProps[\'p\']}>This is a basic Markdown template, with no interpolations going on.</p>
       <p {...elementProps[\'p\']}>This should be</p>
       <ul {...elementProps[\'ul\']}>
-      <li {...elementProps[\'li\']}>easy and;</li>
-      <li {...elementProps[\'li\']}>predictable!</li>
+        <li {...elementProps[\'li\']}>easy and;</li>
+        <li {...elementProps[\'li\']}>predictable!</li>
       </ul>
       <h2 {...elementProps[\'h2\']}>Here\'s a code snippet with no interpolations</h2>
       <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\">npm install -g yarn<br {...elementProps[\'br\']} /></code></pre>
       <h2 {...elementProps[\'h2\']}>Here\'s a code snippet with things which shouldn\'t be treated as interpolations</h2>
-      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\"><span {...elementProps[\'span\']} className=\"hljs-keyword\">function</span> <span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br {...elementProps[\'br\']} />  RUBY=blah<br {...elementProps[\'br\']} />{\'}\'}<br {...elementProps[\'br\']} /></code></pre>
+      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\"><span {...elementProps[\'span\']} className=\"hljs-keyword\">function</span> <span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br {...elementProps[\'br\']} />{\"  \"}RUBY=blah<br {...elementProps[\'br\']} />{\"}\"}<br {...elementProps[\'br\']} /></code></pre>
       <h2 {...elementProps[\'h2\']}>Here\'s a paragraph with a simple interpolation</h2>
       <p {...elementProps[\'p\']}>There are {Object.keys(props).length} props being supplied to this component.</p>
       <h2 {...elementProps[\'h2\']}>Here\'s a code snippet with a simple interpolation</h2>
-      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\"><span {...elementProps[\'span\']} className=\"hljs-keyword\">function</span> <span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br {...elementProps[\'br\']} />  RUBY={props.rubycontent}<br {...elementProps[\'br\']} />{\'}\'}<br {...elementProps[\'br\']} /></code></pre>
+      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\"><span {...elementProps[\'span\']} className=\"hljs-keyword\">function</span> <span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br {...elementProps[\'br\']} />{\"  \"}RUBY={props.rubycontent}<br {...elementProps[\'br\']} />{\"}\"}<br {...elementProps[\'br\']} /></code></pre>
       <h2 {...elementProps[\'h2\']}>Here\'s an unhinted code snippet</h2>
       <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']}><span {...elementProps[\'span\']} className=\"hljs-keyword\">the</span> quick brown fox jumps over <span {...elementProps[\'span\']} className=\"hljs-keyword\">the</span> lazy dog<br {...elementProps[\'br\']} /></code></pre>
       <h2 {...elementProps[\'h2\']}>Here\'s an unhinted snippet with no discernible language</h2>
       <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']}>)<span {...elementProps[\'span\']} className=\"hljs-comment\">()</span><span {...elementProps[\'span\']} className=\"hljs-comment\">(()</span>)<br {...elementProps[\'br\']} /></code></pre>
-      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\">brew tap buildkite/buildkite<br {...elementProps[\'br\']} />brew install --token=<span {...elementProps[\'span\']} className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br {...elementProps[\'br\']} />
-      <span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">function</span></span>() {\'{\'}<br {...elementProps[\'br\']} />  ENV=<span {...elementProps[\'span\']} className=\"hljs-string\">\"foo_bar\"</span><br {...elementProps[\'br\']} />{\'}\'}<br {...elementProps[\'br\']} /></code></pre>
+      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\">brew tap buildkite/buildkite<br {...elementProps[\'br\']} />brew install --token=<span {...elementProps[\'span\']} className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br {...elementProps[\'br\']} />{\"\\n\"}<span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">function</span></span>() {\"{\"}<br {...elementProps[\'br\']} />{\"  \"}ENV=<span {...elementProps[\'span\']} className=\"hljs-string\">\"foo_bar\"</span><br {...elementProps[\'br\']} />{\"}\"}<br {...elementProps[\'br\']} /></code></pre>
     </div>
   );
 };
@@ -8463,11 +8535,12 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         React.createElement(\"br\", null),
-        \"  RUBY=blah\",
+        \"  \",
+        \"RUBY=blah\",
         React.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         React.createElement(\"br\", null)
       )
     ),
@@ -8510,12 +8583,13 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         React.createElement(\"br\", null),
-        \"  RUBY=\",
+        \"  \",
+        \"RUBY=\",
         props.rubycontent,
         React.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         React.createElement(\"br\", null)
       )
     ),
@@ -8589,6 +8663,7 @@ function MarkdownComponent(props) {
         ),
         \" buildkite-agent\",
         React.createElement(\"br\", null),
+        \"\\n\",
         React.createElement(
           \"span\",
           { className: \"hljs-function\" },
@@ -8599,16 +8674,17 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         React.createElement(\"br\", null),
-        \"  ENV=\",
+        \"  \",
+        \"ENV=\",
         React.createElement(
           \"span\",
           { className: \"hljs-string\" },
           \"\\\"foo_bar\\\"\"
         ),
         React.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         React.createElement(\"br\", null)
       )
     )
@@ -8673,7 +8749,8 @@ exports[`Webpack loader with a webpack config object of \`{"implicitlyImportReac
       () 
       {
       <br />
-        RUBY=blah
+        
+      RUBY=blah
       <br />
       }
       <br />
@@ -8708,7 +8785,8 @@ exports[`Webpack loader with a webpack config object of \`{"implicitlyImportReac
       () 
       {
       <br />
-        RUBY=
+        
+      RUBY=
       <br />
       }
       <br />
@@ -8764,6 +8842,8 @@ exports[`Webpack loader with a webpack config object of \`{"implicitlyImportReac
       </span>
        buildkite-agent
       <br />
+      
+      
       <span
         className="hljs-function">
         <span
@@ -8774,7 +8854,8 @@ exports[`Webpack loader with a webpack config object of \`{"implicitlyImportReac
       () 
       {
       <br />
-        ENV=
+        
+      ENV=
       <span
         className="hljs-string">
         \"foo_bar\"
@@ -8811,23 +8892,22 @@ function MarkdownComponent(props) {
       <p>This is a basic Markdown template, with no interpolations going on.</p>
       <p>This should be</p>
       <ul>
-      <li>easy and;</li>
-      <li>predictable!</li>
+        <li>easy and;</li>
+        <li>predictable!</li>
       </ul>
       <h2>Here\'s a code snippet with no interpolations</h2>
       <pre><code className=\"language-bash\">npm install -g yarn<br /></code></pre>
       <h2>Here\'s a code snippet with things which shouldn\'t be treated as interpolations</h2>
-      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br />  RUBY=blah<br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br />{\"  \"}RUBY=blah<br />{\"}\"}<br /></code></pre>
       <h2>Here\'s a paragraph with a simple interpolation</h2>
       <p>There are {Object.keys(props).length} props being supplied to this component.</p>
       <h2>Here\'s a code snippet with a simple interpolation</h2>
-      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br />  RUBY={props.rubycontent}<br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br />{\"  \"}RUBY={props.rubycontent}<br />{\"}\"}<br /></code></pre>
       <h2>Here\'s an unhinted code snippet</h2>
       <pre><code><span className=\"hljs-keyword\">the</span> quick brown fox jumps over <span className=\"hljs-keyword\">the</span> lazy dog<br /></code></pre>
       <h2>Here\'s an unhinted snippet with no discernible language</h2>
       <pre><code>)<span className=\"hljs-comment\">()</span><span className=\"hljs-comment\">(()</span>)<br /></code></pre>
-      <pre><code className=\"language-bash\">brew tap buildkite/buildkite<br />brew install --token=<span className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br />
-      <span className=\"hljs-function\"><span className=\"hljs-title\">function</span></span>() {\'{\'}<br />  ENV=<span className=\"hljs-string\">\"foo_bar\"</span><br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\">brew tap buildkite/buildkite<br />brew install --token=<span className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br />{\"\\n\"}<span className=\"hljs-function\"><span className=\"hljs-title\">function</span></span>() {\"{\"}<br />{\"  \"}ENV=<span className=\"hljs-string\">\"foo_bar\"</span><br />{\"}\"}<br /></code></pre>
     </div>
   );
 };
@@ -9359,11 +9439,12 @@ function MarkdownComponent(props) {
           )
         ),
         \'() \',
-        \'{\',
+        \"{\",
         React.createElement(\'br\', elementProps[\'br\']),
-        \'  RUBY=blah\',
+        \"  \",
+        \'RUBY=blah\',
         React.createElement(\'br\', elementProps[\'br\']),
-        \'}\',
+        \"}\",
         React.createElement(\'br\', elementProps[\'br\'])
       )
     ),
@@ -9406,12 +9487,13 @@ function MarkdownComponent(props) {
           )
         ),
         \'() \',
-        \'{\',
+        \"{\",
         React.createElement(\'br\', elementProps[\'br\']),
-        \'  RUBY=\',
+        \"  \",
+        \'RUBY=\',
         props.rubycontent,
         React.createElement(\'br\', elementProps[\'br\']),
-        \'}\',
+        \"}\",
         React.createElement(\'br\', elementProps[\'br\'])
       )
     ),
@@ -9485,6 +9567,7 @@ function MarkdownComponent(props) {
         ),
         \' buildkite-agent\',
         React.createElement(\'br\', elementProps[\'br\']),
+        \"\\n\",
         React.createElement(
           \'span\',
           _extends({}, elementProps[\'span\'], { className: \'hljs-function\' }),
@@ -9495,16 +9578,17 @@ function MarkdownComponent(props) {
           )
         ),
         \'() \',
-        \'{\',
+        \"{\",
         React.createElement(\'br\', elementProps[\'br\']),
-        \'  ENV=\',
+        \"  \",
+        \'ENV=\',
         React.createElement(
           \'span\',
           _extends({}, elementProps[\'span\'], { className: \'hljs-string\' }),
           \'\"foo_bar\"\'
         ),
         React.createElement(\'br\', elementProps[\'br\']),
-        \'}\',
+        \"}\",
         React.createElement(\'br\', elementProps[\'br\'])
       )
     )
@@ -9569,7 +9653,8 @@ exports[`Webpack loader with a webpack config object of \`{"implicitlyImportReac
       () 
       {
       <br />
-        RUBY=blah
+        
+      RUBY=blah
       <br />
       }
       <br />
@@ -9604,7 +9689,8 @@ exports[`Webpack loader with a webpack config object of \`{"implicitlyImportReac
       () 
       {
       <br />
-        RUBY=
+        
+      RUBY=
       <br />
       }
       <br />
@@ -9660,6 +9746,8 @@ exports[`Webpack loader with a webpack config object of \`{"implicitlyImportReac
       </span>
        buildkite-agent
       <br />
+      
+      
       <span
         className="hljs-function">
         <span
@@ -9670,7 +9758,8 @@ exports[`Webpack loader with a webpack config object of \`{"implicitlyImportReac
       () 
       {
       <br />
-        ENV=
+        
+      ENV=
       <span
         className="hljs-string">
         \"foo_bar\"
@@ -9713,23 +9802,22 @@ function MarkdownComponent(props) {
       <p {...elementProps[\'p\']}>This is a basic Markdown template, with no interpolations going on.</p>
       <p {...elementProps[\'p\']}>This should be</p>
       <ul {...elementProps[\'ul\']}>
-      <li {...elementProps[\'li\']}>easy and;</li>
-      <li {...elementProps[\'li\']}>predictable!</li>
+        <li {...elementProps[\'li\']}>easy and;</li>
+        <li {...elementProps[\'li\']}>predictable!</li>
       </ul>
       <h2 {...elementProps[\'h2\']}>Here\'s a code snippet with no interpolations</h2>
       <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\">npm install -g yarn<br {...elementProps[\'br\']} /></code></pre>
       <h2 {...elementProps[\'h2\']}>Here\'s a code snippet with things which shouldn\'t be treated as interpolations</h2>
-      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\"><span {...elementProps[\'span\']} className=\"hljs-keyword\">function</span> <span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br {...elementProps[\'br\']} />  RUBY=blah<br {...elementProps[\'br\']} />{\'}\'}<br {...elementProps[\'br\']} /></code></pre>
+      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\"><span {...elementProps[\'span\']} className=\"hljs-keyword\">function</span> <span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br {...elementProps[\'br\']} />{\"  \"}RUBY=blah<br {...elementProps[\'br\']} />{\"}\"}<br {...elementProps[\'br\']} /></code></pre>
       <h2 {...elementProps[\'h2\']}>Here\'s a paragraph with a simple interpolation</h2>
       <p {...elementProps[\'p\']}>There are {Object.keys(props).length} props being supplied to this component.</p>
       <h2 {...elementProps[\'h2\']}>Here\'s a code snippet with a simple interpolation</h2>
-      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\"><span {...elementProps[\'span\']} className=\"hljs-keyword\">function</span> <span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br {...elementProps[\'br\']} />  RUBY={props.rubycontent}<br {...elementProps[\'br\']} />{\'}\'}<br {...elementProps[\'br\']} /></code></pre>
+      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\"><span {...elementProps[\'span\']} className=\"hljs-keyword\">function</span> <span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br {...elementProps[\'br\']} />{\"  \"}RUBY={props.rubycontent}<br {...elementProps[\'br\']} />{\"}\"}<br {...elementProps[\'br\']} /></code></pre>
       <h2 {...elementProps[\'h2\']}>Here\'s an unhinted code snippet</h2>
       <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']}><span {...elementProps[\'span\']} className=\"hljs-keyword\">the</span> quick brown fox jumps over <span {...elementProps[\'span\']} className=\"hljs-keyword\">the</span> lazy dog<br {...elementProps[\'br\']} /></code></pre>
       <h2 {...elementProps[\'h2\']}>Here\'s an unhinted snippet with no discernible language</h2>
       <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']}>)<span {...elementProps[\'span\']} className=\"hljs-comment\">()</span><span {...elementProps[\'span\']} className=\"hljs-comment\">(()</span>)<br {...elementProps[\'br\']} /></code></pre>
-      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\">brew tap buildkite/buildkite<br {...elementProps[\'br\']} />brew install --token=<span {...elementProps[\'span\']} className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br {...elementProps[\'br\']} />
-      <span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">function</span></span>() {\'{\'}<br {...elementProps[\'br\']} />  ENV=<span {...elementProps[\'span\']} className=\"hljs-string\">\"foo_bar\"</span><br {...elementProps[\'br\']} />{\'}\'}<br {...elementProps[\'br\']} /></code></pre>
+      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\">brew tap buildkite/buildkite<br {...elementProps[\'br\']} />brew install --token=<span {...elementProps[\'span\']} className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br {...elementProps[\'br\']} />{\"\\n\"}<span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">function</span></span>() {\"{\"}<br {...elementProps[\'br\']} />{\"  \"}ENV=<span {...elementProps[\'span\']} className=\"hljs-string\">\"foo_bar\"</span><br {...elementProps[\'br\']} />{\"}\"}<br {...elementProps[\'br\']} /></code></pre>
     </div>
   );
 };
@@ -10300,11 +10388,12 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         React.createElement(\"br\", null),
-        \"  RUBY=blah\",
+        \"  \",
+        \"RUBY=blah\",
         React.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         React.createElement(\"br\", null)
       )
     ),
@@ -10347,12 +10436,13 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         React.createElement(\"br\", null),
-        \"  RUBY=\",
+        \"  \",
+        \"RUBY=\",
         props.rubycontent,
         React.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         React.createElement(\"br\", null)
       )
     ),
@@ -10426,6 +10516,7 @@ function MarkdownComponent(props) {
         ),
         \" buildkite-agent\",
         React.createElement(\"br\", null),
+        \"\\n\",
         React.createElement(
           \"span\",
           { className: \"hljs-function\" },
@@ -10436,16 +10527,17 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         React.createElement(\"br\", null),
-        \"  ENV=\",
+        \"  \",
+        \"ENV=\",
         React.createElement(
           \"span\",
           { className: \"hljs-string\" },
           \"\\\"foo_bar\\\"\"
         ),
         React.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         React.createElement(\"br\", null)
       )
     )
@@ -10510,7 +10602,8 @@ exports[`Webpack loader with a webpack config object of \`{"implicitlyImportReac
       () 
       {
       <br />
-        RUBY=blah
+        
+      RUBY=blah
       <br />
       }
       <br />
@@ -10545,7 +10638,8 @@ exports[`Webpack loader with a webpack config object of \`{"implicitlyImportReac
       () 
       {
       <br />
-        RUBY=
+        
+      RUBY=
       <br />
       }
       <br />
@@ -10601,6 +10695,8 @@ exports[`Webpack loader with a webpack config object of \`{"implicitlyImportReac
       </span>
        buildkite-agent
       <br />
+      
+      
       <span
         className="hljs-function">
         <span
@@ -10611,7 +10707,8 @@ exports[`Webpack loader with a webpack config object of \`{"implicitlyImportReac
       () 
       {
       <br />
-        ENV=
+        
+      ENV=
       <span
         className="hljs-string">
         \"foo_bar\"
@@ -10648,23 +10745,22 @@ function MarkdownComponent(props) {
       <p>This is a basic Markdown template, with no interpolations going on.</p>
       <p>This should be</p>
       <ul>
-      <li>easy and;</li>
-      <li>predictable!</li>
+        <li>easy and;</li>
+        <li>predictable!</li>
       </ul>
       <h2>Here\'s a code snippet with no interpolations</h2>
       <pre><code className=\"language-bash\">npm install -g yarn<br /></code></pre>
       <h2>Here\'s a code snippet with things which shouldn\'t be treated as interpolations</h2>
-      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br />  RUBY=blah<br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br />{\"  \"}RUBY=blah<br />{\"}\"}<br /></code></pre>
       <h2>Here\'s a paragraph with a simple interpolation</h2>
       <p>There are {Object.keys(props).length} props being supplied to this component.</p>
       <h2>Here\'s a code snippet with a simple interpolation</h2>
-      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br />  RUBY={props.rubycontent}<br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br />{\"  \"}RUBY={props.rubycontent}<br />{\"}\"}<br /></code></pre>
       <h2>Here\'s an unhinted code snippet</h2>
       <pre><code><span className=\"hljs-keyword\">the</span> quick brown fox jumps over <span className=\"hljs-keyword\">the</span> lazy dog<br /></code></pre>
       <h2>Here\'s an unhinted snippet with no discernible language</h2>
       <pre><code>)<span className=\"hljs-comment\">()</span><span className=\"hljs-comment\">(()</span>)<br /></code></pre>
-      <pre><code className=\"language-bash\">brew tap buildkite/buildkite<br />brew install --token=<span className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br />
-      <span className=\"hljs-function\"><span className=\"hljs-title\">function</span></span>() {\'{\'}<br />  ENV=<span className=\"hljs-string\">\"foo_bar\"</span><br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\">brew tap buildkite/buildkite<br />brew install --token=<span className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br />{\"\\n\"}<span className=\"hljs-function\"><span className=\"hljs-title\">function</span></span>() {\"{\"}<br />{\"  \"}ENV=<span className=\"hljs-string\">\"foo_bar\"</span><br />{\"}\"}<br /></code></pre>
     </div>
   );
 };
@@ -11193,11 +11289,12 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         _react2.default.createElement(\"br\", null),
-        \"  RUBY=blah\",
+        \"  \",
+        \"RUBY=blah\",
         _react2.default.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         _react2.default.createElement(\"br\", null)
       )
     ),
@@ -11240,12 +11337,13 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         _react2.default.createElement(\"br\", null),
-        \"  RUBY=\",
+        \"  \",
+        \"RUBY=\",
         props.rubycontent,
         _react2.default.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         _react2.default.createElement(\"br\", null)
       )
     ),
@@ -11319,6 +11417,7 @@ function MarkdownComponent(props) {
         ),
         \" buildkite-agent\",
         _react2.default.createElement(\"br\", null),
+        \"\\n\",
         _react2.default.createElement(
           \"span\",
           { className: \"hljs-function\" },
@@ -11329,16 +11428,17 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         _react2.default.createElement(\"br\", null),
-        \"  ENV=\",
+        \"  \",
+        \"ENV=\",
         _react2.default.createElement(
           \"span\",
           { className: \"hljs-string\" },
           \"\\\"foo_bar\\\"\"
         ),
         _react2.default.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         _react2.default.createElement(\"br\", null)
       )
     )
@@ -11403,7 +11503,8 @@ exports[`Webpack loader with a webpack config object of \`{"implicitlyImportReac
       () 
       {
       <br />
-        RUBY=blah
+        
+      RUBY=blah
       <br />
       }
       <br />
@@ -11438,7 +11539,8 @@ exports[`Webpack loader with a webpack config object of \`{"implicitlyImportReac
       () 
       {
       <br />
-        RUBY=
+        
+      RUBY=
       <br />
       }
       <br />
@@ -11494,6 +11596,8 @@ exports[`Webpack loader with a webpack config object of \`{"implicitlyImportReac
       </span>
        buildkite-agent
       <br />
+      
+      
       <span
         className="hljs-function">
         <span
@@ -11504,7 +11608,8 @@ exports[`Webpack loader with a webpack config object of \`{"implicitlyImportReac
       () 
       {
       <br />
-        ENV=
+        
+      ENV=
       <span
         className="hljs-string">
         \"foo_bar\"
@@ -11542,23 +11647,22 @@ function MarkdownComponent(props) {
       <p>This is a basic Markdown template, with no interpolations going on.</p>
       <p>This should be</p>
       <ul>
-      <li>easy and;</li>
-      <li>predictable!</li>
+        <li>easy and;</li>
+        <li>predictable!</li>
       </ul>
       <h2>Here\'s a code snippet with no interpolations</h2>
       <pre><code className=\"language-bash\">npm install -g yarn<br /></code></pre>
       <h2>Here\'s a code snippet with things which shouldn\'t be treated as interpolations</h2>
-      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br />  RUBY=blah<br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br />{\"  \"}RUBY=blah<br />{\"}\"}<br /></code></pre>
       <h2>Here\'s a paragraph with a simple interpolation</h2>
       <p>There are {Object.keys(props).length} props being supplied to this component.</p>
       <h2>Here\'s a code snippet with a simple interpolation</h2>
-      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br />  RUBY={props.rubycontent}<br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br />{\"  \"}RUBY={props.rubycontent}<br />{\"}\"}<br /></code></pre>
       <h2>Here\'s an unhinted code snippet</h2>
       <pre><code><span className=\"hljs-keyword\">the</span> quick brown fox jumps over <span className=\"hljs-keyword\">the</span> lazy dog<br /></code></pre>
       <h2>Here\'s an unhinted snippet with no discernible language</h2>
       <pre><code>)<span className=\"hljs-comment\">()</span><span className=\"hljs-comment\">(()</span>)<br /></code></pre>
-      <pre><code className=\"language-bash\">brew tap buildkite/buildkite<br />brew install --token=<span className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br />
-      <span className=\"hljs-function\"><span className=\"hljs-title\">function</span></span>() {\'{\'}<br />  ENV=<span className=\"hljs-string\">\"foo_bar\"</span><br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\">brew tap buildkite/buildkite<br />brew install --token=<span className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br />{\"\\n\"}<span className=\"hljs-function\"><span className=\"hljs-title\">function</span></span>() {\"{\"}<br />{\"  \"}ENV=<span className=\"hljs-string\">\"foo_bar\"</span><br />{\"}\"}<br /></code></pre>
     </div>
   );
 };
@@ -12121,11 +12225,12 @@ function MarkdownComponent(props) {
           )
         ),
         \'() \',
-        \'{\',
+        \"{\",
         _react2.default.createElement(\'br\', elementProps[\'br\']),
-        \'  RUBY=blah\',
+        \"  \",
+        \'RUBY=blah\',
         _react2.default.createElement(\'br\', elementProps[\'br\']),
-        \'}\',
+        \"}\",
         _react2.default.createElement(\'br\', elementProps[\'br\'])
       )
     ),
@@ -12168,12 +12273,13 @@ function MarkdownComponent(props) {
           )
         ),
         \'() \',
-        \'{\',
+        \"{\",
         _react2.default.createElement(\'br\', elementProps[\'br\']),
-        \'  RUBY=\',
+        \"  \",
+        \'RUBY=\',
         props.rubycontent,
         _react2.default.createElement(\'br\', elementProps[\'br\']),
-        \'}\',
+        \"}\",
         _react2.default.createElement(\'br\', elementProps[\'br\'])
       )
     ),
@@ -12247,6 +12353,7 @@ function MarkdownComponent(props) {
         ),
         \' buildkite-agent\',
         _react2.default.createElement(\'br\', elementProps[\'br\']),
+        \"\\n\",
         _react2.default.createElement(
           \'span\',
           _extends({}, elementProps[\'span\'], { className: \'hljs-function\' }),
@@ -12257,16 +12364,17 @@ function MarkdownComponent(props) {
           )
         ),
         \'() \',
-        \'{\',
+        \"{\",
         _react2.default.createElement(\'br\', elementProps[\'br\']),
-        \'  ENV=\',
+        \"  \",
+        \'ENV=\',
         _react2.default.createElement(
           \'span\',
           _extends({}, elementProps[\'span\'], { className: \'hljs-string\' }),
           \'\"foo_bar\"\'
         ),
         _react2.default.createElement(\'br\', elementProps[\'br\']),
-        \'}\',
+        \"}\",
         _react2.default.createElement(\'br\', elementProps[\'br\'])
       )
     )
@@ -12331,7 +12439,8 @@ exports[`Webpack loader with a webpack config object of \`{"implicitlyImportReac
       () 
       {
       <br />
-        RUBY=blah
+        
+      RUBY=blah
       <br />
       }
       <br />
@@ -12366,7 +12475,8 @@ exports[`Webpack loader with a webpack config object of \`{"implicitlyImportReac
       () 
       {
       <br />
-        RUBY=
+        
+      RUBY=
       <br />
       }
       <br />
@@ -12422,6 +12532,8 @@ exports[`Webpack loader with a webpack config object of \`{"implicitlyImportReac
       </span>
        buildkite-agent
       <br />
+      
+      
       <span
         className="hljs-function">
         <span
@@ -12432,7 +12544,8 @@ exports[`Webpack loader with a webpack config object of \`{"implicitlyImportReac
       () 
       {
       <br />
-        ENV=
+        
+      ENV=
       <span
         className="hljs-string">
         \"foo_bar\"
@@ -12476,23 +12589,22 @@ function MarkdownComponent(props) {
       <p {...elementProps[\'p\']}>This is a basic Markdown template, with no interpolations going on.</p>
       <p {...elementProps[\'p\']}>This should be</p>
       <ul {...elementProps[\'ul\']}>
-      <li {...elementProps[\'li\']}>easy and;</li>
-      <li {...elementProps[\'li\']}>predictable!</li>
+        <li {...elementProps[\'li\']}>easy and;</li>
+        <li {...elementProps[\'li\']}>predictable!</li>
       </ul>
       <h2 {...elementProps[\'h2\']}>Here\'s a code snippet with no interpolations</h2>
       <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\">npm install -g yarn<br {...elementProps[\'br\']} /></code></pre>
       <h2 {...elementProps[\'h2\']}>Here\'s a code snippet with things which shouldn\'t be treated as interpolations</h2>
-      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\"><span {...elementProps[\'span\']} className=\"hljs-keyword\">function</span> <span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br {...elementProps[\'br\']} />  RUBY=blah<br {...elementProps[\'br\']} />{\'}\'}<br {...elementProps[\'br\']} /></code></pre>
+      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\"><span {...elementProps[\'span\']} className=\"hljs-keyword\">function</span> <span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br {...elementProps[\'br\']} />{\"  \"}RUBY=blah<br {...elementProps[\'br\']} />{\"}\"}<br {...elementProps[\'br\']} /></code></pre>
       <h2 {...elementProps[\'h2\']}>Here\'s a paragraph with a simple interpolation</h2>
       <p {...elementProps[\'p\']}>There are {Object.keys(props).length} props being supplied to this component.</p>
       <h2 {...elementProps[\'h2\']}>Here\'s a code snippet with a simple interpolation</h2>
-      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\"><span {...elementProps[\'span\']} className=\"hljs-keyword\">function</span> <span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br {...elementProps[\'br\']} />  RUBY={props.rubycontent}<br {...elementProps[\'br\']} />{\'}\'}<br {...elementProps[\'br\']} /></code></pre>
+      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\"><span {...elementProps[\'span\']} className=\"hljs-keyword\">function</span> <span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br {...elementProps[\'br\']} />{\"  \"}RUBY={props.rubycontent}<br {...elementProps[\'br\']} />{\"}\"}<br {...elementProps[\'br\']} /></code></pre>
       <h2 {...elementProps[\'h2\']}>Here\'s an unhinted code snippet</h2>
       <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']}><span {...elementProps[\'span\']} className=\"hljs-keyword\">the</span> quick brown fox jumps over <span {...elementProps[\'span\']} className=\"hljs-keyword\">the</span> lazy dog<br {...elementProps[\'br\']} /></code></pre>
       <h2 {...elementProps[\'h2\']}>Here\'s an unhinted snippet with no discernible language</h2>
       <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']}>)<span {...elementProps[\'span\']} className=\"hljs-comment\">()</span><span {...elementProps[\'span\']} className=\"hljs-comment\">(()</span>)<br {...elementProps[\'br\']} /></code></pre>
-      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\">brew tap buildkite/buildkite<br {...elementProps[\'br\']} />brew install --token=<span {...elementProps[\'span\']} className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br {...elementProps[\'br\']} />
-      <span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">function</span></span>() {\'{\'}<br {...elementProps[\'br\']} />  ENV=<span {...elementProps[\'span\']} className=\"hljs-string\">\"foo_bar\"</span><br {...elementProps[\'br\']} />{\'}\'}<br {...elementProps[\'br\']} /></code></pre>
+      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\">brew tap buildkite/buildkite<br {...elementProps[\'br\']} />brew install --token=<span {...elementProps[\'span\']} className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br {...elementProps[\'br\']} />{\"\\n\"}<span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">function</span></span>() {\"{\"}<br {...elementProps[\'br\']} />{\"  \"}ENV=<span {...elementProps[\'span\']} className=\"hljs-string\">\"foo_bar\"</span><br {...elementProps[\'br\']} />{\"}\"}<br {...elementProps[\'br\']} /></code></pre>
     </div>
   );
 };
@@ -13095,11 +13207,12 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         _react2.default.createElement(\"br\", null),
-        \"  RUBY=blah\",
+        \"  \",
+        \"RUBY=blah\",
         _react2.default.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         _react2.default.createElement(\"br\", null)
       )
     ),
@@ -13142,12 +13255,13 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         _react2.default.createElement(\"br\", null),
-        \"  RUBY=\",
+        \"  \",
+        \"RUBY=\",
         props.rubycontent,
         _react2.default.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         _react2.default.createElement(\"br\", null)
       )
     ),
@@ -13221,6 +13335,7 @@ function MarkdownComponent(props) {
         ),
         \" buildkite-agent\",
         _react2.default.createElement(\"br\", null),
+        \"\\n\",
         _react2.default.createElement(
           \"span\",
           { className: \"hljs-function\" },
@@ -13231,16 +13346,17 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         _react2.default.createElement(\"br\", null),
-        \"  ENV=\",
+        \"  \",
+        \"ENV=\",
         _react2.default.createElement(
           \"span\",
           { className: \"hljs-string\" },
           \"\\\"foo_bar\\\"\"
         ),
         _react2.default.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         _react2.default.createElement(\"br\", null)
       )
     )
@@ -13305,7 +13421,8 @@ exports[`Webpack loader with a webpack config object of \`{"implicitlyImportReac
       () 
       {
       <br />
-        RUBY=blah
+        
+      RUBY=blah
       <br />
       }
       <br />
@@ -13340,7 +13457,8 @@ exports[`Webpack loader with a webpack config object of \`{"implicitlyImportReac
       () 
       {
       <br />
-        RUBY=
+        
+      RUBY=
       <br />
       }
       <br />
@@ -13396,6 +13514,8 @@ exports[`Webpack loader with a webpack config object of \`{"implicitlyImportReac
       </span>
        buildkite-agent
       <br />
+      
+      
       <span
         className="hljs-function">
         <span
@@ -13406,7 +13526,8 @@ exports[`Webpack loader with a webpack config object of \`{"implicitlyImportReac
       () 
       {
       <br />
-        ENV=
+        
+      ENV=
       <span
         className="hljs-string">
         \"foo_bar\"
@@ -13444,23 +13565,22 @@ function MarkdownComponent(props) {
       <p>This is a basic Markdown template, with no interpolations going on.</p>
       <p>This should be</p>
       <ul>
-      <li>easy and;</li>
-      <li>predictable!</li>
+        <li>easy and;</li>
+        <li>predictable!</li>
       </ul>
       <h2>Here\'s a code snippet with no interpolations</h2>
       <pre><code className=\"language-bash\">npm install -g yarn<br /></code></pre>
       <h2>Here\'s a code snippet with things which shouldn\'t be treated as interpolations</h2>
-      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br />  RUBY=blah<br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br />{\"  \"}RUBY=blah<br />{\"}\"}<br /></code></pre>
       <h2>Here\'s a paragraph with a simple interpolation</h2>
       <p>There are {Object.keys(props).length} props being supplied to this component.</p>
       <h2>Here\'s a code snippet with a simple interpolation</h2>
-      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br />  RUBY={props.rubycontent}<br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br />{\"  \"}RUBY={props.rubycontent}<br />{\"}\"}<br /></code></pre>
       <h2>Here\'s an unhinted code snippet</h2>
       <pre><code><span className=\"hljs-keyword\">the</span> quick brown fox jumps over <span className=\"hljs-keyword\">the</span> lazy dog<br /></code></pre>
       <h2>Here\'s an unhinted snippet with no discernible language</h2>
       <pre><code>)<span className=\"hljs-comment\">()</span><span className=\"hljs-comment\">(()</span>)<br /></code></pre>
-      <pre><code className=\"language-bash\">brew tap buildkite/buildkite<br />brew install --token=<span className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br />
-      <span className=\"hljs-function\"><span className=\"hljs-title\">function</span></span>() {\'{\'}<br />  ENV=<span className=\"hljs-string\">\"foo_bar\"</span><br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\">brew tap buildkite/buildkite<br />brew install --token=<span className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br />{\"\\n\"}<span className=\"hljs-function\"><span className=\"hljs-title\">function</span></span>() {\"{\"}<br />{\"  \"}ENV=<span className=\"hljs-string\">\"foo_bar\"</span><br />{\"}\"}<br /></code></pre>
     </div>
   );
 };
@@ -14009,11 +14129,12 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         React.createElement(\"br\", null),
-        \"  RUBY=blah\",
+        \"  \",
+        \"RUBY=blah\",
         React.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         React.createElement(\"br\", null)
       )
     ),
@@ -14056,12 +14177,13 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         React.createElement(\"br\", null),
-        \"  RUBY=\",
+        \"  \",
+        \"RUBY=\",
         props.rubycontent,
         React.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         React.createElement(\"br\", null)
       )
     ),
@@ -14135,6 +14257,7 @@ function MarkdownComponent(props) {
         ),
         \" buildkite-agent\",
         React.createElement(\"br\", null),
+        \"\\n\",
         React.createElement(
           \"span\",
           { className: \"hljs-function\" },
@@ -14145,16 +14268,17 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         React.createElement(\"br\", null),
-        \"  ENV=\",
+        \"  \",
+        \"ENV=\",
         React.createElement(
           \"span\",
           { className: \"hljs-string\" },
           \"\\\"foo_bar\\\"\"
         ),
         React.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         React.createElement(\"br\", null)
       )
     )
@@ -14219,7 +14343,8 @@ exports[`Webpack loader with a webpack config object of \`{"passElementProps":fa
       () 
       {
       <br />
-        RUBY=blah
+        
+      RUBY=blah
       <br />
       }
       <br />
@@ -14254,7 +14379,8 @@ exports[`Webpack loader with a webpack config object of \`{"passElementProps":fa
       () 
       {
       <br />
-        RUBY=
+        
+      RUBY=
       <br />
       }
       <br />
@@ -14310,6 +14436,8 @@ exports[`Webpack loader with a webpack config object of \`{"passElementProps":fa
       </span>
        buildkite-agent
       <br />
+      
+      
       <span
         className="hljs-function">
         <span
@@ -14320,7 +14448,8 @@ exports[`Webpack loader with a webpack config object of \`{"passElementProps":fa
       () 
       {
       <br />
-        ENV=
+        
+      ENV=
       <span
         className="hljs-string">
         \"foo_bar\"
@@ -14357,23 +14486,22 @@ function MarkdownComponent(props) {
       <p>This is a basic Markdown template, with no interpolations going on.</p>
       <p>This should be</p>
       <ul>
-      <li>easy and;</li>
-      <li>predictable!</li>
+        <li>easy and;</li>
+        <li>predictable!</li>
       </ul>
       <h2>Here\'s a code snippet with no interpolations</h2>
       <pre><code className=\"language-bash\">npm install -g yarn<br /></code></pre>
       <h2>Here\'s a code snippet with things which shouldn\'t be treated as interpolations</h2>
-      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br />  RUBY=blah<br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br />{\"  \"}RUBY=blah<br />{\"}\"}<br /></code></pre>
       <h2>Here\'s a paragraph with a simple interpolation</h2>
       <p>There are {Object.keys(props).length} props being supplied to this component.</p>
       <h2>Here\'s a code snippet with a simple interpolation</h2>
-      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br />  RUBY={props.rubycontent}<br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br />{\"  \"}RUBY={props.rubycontent}<br />{\"}\"}<br /></code></pre>
       <h2>Here\'s an unhinted code snippet</h2>
       <pre><code><span className=\"hljs-keyword\">the</span> quick brown fox jumps over <span className=\"hljs-keyword\">the</span> lazy dog<br /></code></pre>
       <h2>Here\'s an unhinted snippet with no discernible language</h2>
       <pre><code>)<span className=\"hljs-comment\">()</span><span className=\"hljs-comment\">(()</span>)<br /></code></pre>
-      <pre><code className=\"language-bash\">brew tap buildkite/buildkite<br />brew install --token=<span className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br />
-      <span className=\"hljs-function\"><span className=\"hljs-title\">function</span></span>() {\'{\'}<br />  ENV=<span className=\"hljs-string\">\"foo_bar\"</span><br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\">brew tap buildkite/buildkite<br />brew install --token=<span className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br />{\"\\n\"}<span className=\"hljs-function\"><span className=\"hljs-title\">function</span></span>() {\"{\"}<br />{\"  \"}ENV=<span className=\"hljs-string\">\"foo_bar\"</span><br />{\"}\"}<br /></code></pre>
     </div>
   );
 };
@@ -14905,11 +15033,12 @@ function MarkdownComponent(props) {
           )
         ),
         \'() \',
-        \'{\',
+        \"{\",
         React.createElement(\'br\', elementProps[\'br\']),
-        \'  RUBY=blah\',
+        \"  \",
+        \'RUBY=blah\',
         React.createElement(\'br\', elementProps[\'br\']),
-        \'}\',
+        \"}\",
         React.createElement(\'br\', elementProps[\'br\'])
       )
     ),
@@ -14952,12 +15081,13 @@ function MarkdownComponent(props) {
           )
         ),
         \'() \',
-        \'{\',
+        \"{\",
         React.createElement(\'br\', elementProps[\'br\']),
-        \'  RUBY=\',
+        \"  \",
+        \'RUBY=\',
         props.rubycontent,
         React.createElement(\'br\', elementProps[\'br\']),
-        \'}\',
+        \"}\",
         React.createElement(\'br\', elementProps[\'br\'])
       )
     ),
@@ -15031,6 +15161,7 @@ function MarkdownComponent(props) {
         ),
         \' buildkite-agent\',
         React.createElement(\'br\', elementProps[\'br\']),
+        \"\\n\",
         React.createElement(
           \'span\',
           _extends({}, elementProps[\'span\'], { className: \'hljs-function\' }),
@@ -15041,16 +15172,17 @@ function MarkdownComponent(props) {
           )
         ),
         \'() \',
-        \'{\',
+        \"{\",
         React.createElement(\'br\', elementProps[\'br\']),
-        \'  ENV=\',
+        \"  \",
+        \'ENV=\',
         React.createElement(
           \'span\',
           _extends({}, elementProps[\'span\'], { className: \'hljs-string\' }),
           \'\"foo_bar\"\'
         ),
         React.createElement(\'br\', elementProps[\'br\']),
-        \'}\',
+        \"}\",
         React.createElement(\'br\', elementProps[\'br\'])
       )
     )
@@ -15115,7 +15247,8 @@ exports[`Webpack loader with a webpack config object of \`{"passElementProps":tr
       () 
       {
       <br />
-        RUBY=blah
+        
+      RUBY=blah
       <br />
       }
       <br />
@@ -15150,7 +15283,8 @@ exports[`Webpack loader with a webpack config object of \`{"passElementProps":tr
       () 
       {
       <br />
-        RUBY=
+        
+      RUBY=
       <br />
       }
       <br />
@@ -15206,6 +15340,8 @@ exports[`Webpack loader with a webpack config object of \`{"passElementProps":tr
       </span>
        buildkite-agent
       <br />
+      
+      
       <span
         className="hljs-function">
         <span
@@ -15216,7 +15352,8 @@ exports[`Webpack loader with a webpack config object of \`{"passElementProps":tr
       () 
       {
       <br />
-        ENV=
+        
+      ENV=
       <span
         className="hljs-string">
         \"foo_bar\"
@@ -15259,23 +15396,22 @@ function MarkdownComponent(props) {
       <p {...elementProps[\'p\']}>This is a basic Markdown template, with no interpolations going on.</p>
       <p {...elementProps[\'p\']}>This should be</p>
       <ul {...elementProps[\'ul\']}>
-      <li {...elementProps[\'li\']}>easy and;</li>
-      <li {...elementProps[\'li\']}>predictable!</li>
+        <li {...elementProps[\'li\']}>easy and;</li>
+        <li {...elementProps[\'li\']}>predictable!</li>
       </ul>
       <h2 {...elementProps[\'h2\']}>Here\'s a code snippet with no interpolations</h2>
       <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\">npm install -g yarn<br {...elementProps[\'br\']} /></code></pre>
       <h2 {...elementProps[\'h2\']}>Here\'s a code snippet with things which shouldn\'t be treated as interpolations</h2>
-      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\"><span {...elementProps[\'span\']} className=\"hljs-keyword\">function</span> <span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br {...elementProps[\'br\']} />  RUBY=blah<br {...elementProps[\'br\']} />{\'}\'}<br {...elementProps[\'br\']} /></code></pre>
+      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\"><span {...elementProps[\'span\']} className=\"hljs-keyword\">function</span> <span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br {...elementProps[\'br\']} />{\"  \"}RUBY=blah<br {...elementProps[\'br\']} />{\"}\"}<br {...elementProps[\'br\']} /></code></pre>
       <h2 {...elementProps[\'h2\']}>Here\'s a paragraph with a simple interpolation</h2>
       <p {...elementProps[\'p\']}>There are {Object.keys(props).length} props being supplied to this component.</p>
       <h2 {...elementProps[\'h2\']}>Here\'s a code snippet with a simple interpolation</h2>
-      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\"><span {...elementProps[\'span\']} className=\"hljs-keyword\">function</span> <span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br {...elementProps[\'br\']} />  RUBY={props.rubycontent}<br {...elementProps[\'br\']} />{\'}\'}<br {...elementProps[\'br\']} /></code></pre>
+      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\"><span {...elementProps[\'span\']} className=\"hljs-keyword\">function</span> <span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br {...elementProps[\'br\']} />{\"  \"}RUBY={props.rubycontent}<br {...elementProps[\'br\']} />{\"}\"}<br {...elementProps[\'br\']} /></code></pre>
       <h2 {...elementProps[\'h2\']}>Here\'s an unhinted code snippet</h2>
       <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']}><span {...elementProps[\'span\']} className=\"hljs-keyword\">the</span> quick brown fox jumps over <span {...elementProps[\'span\']} className=\"hljs-keyword\">the</span> lazy dog<br {...elementProps[\'br\']} /></code></pre>
       <h2 {...elementProps[\'h2\']}>Here\'s an unhinted snippet with no discernible language</h2>
       <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']}>)<span {...elementProps[\'span\']} className=\"hljs-comment\">()</span><span {...elementProps[\'span\']} className=\"hljs-comment\">(()</span>)<br {...elementProps[\'br\']} /></code></pre>
-      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\">brew tap buildkite/buildkite<br {...elementProps[\'br\']} />brew install --token=<span {...elementProps[\'span\']} className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br {...elementProps[\'br\']} />
-      <span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">function</span></span>() {\'{\'}<br {...elementProps[\'br\']} />  ENV=<span {...elementProps[\'span\']} className=\"hljs-string\">\"foo_bar\"</span><br {...elementProps[\'br\']} />{\'}\'}<br {...elementProps[\'br\']} /></code></pre>
+      <pre {...elementProps[\'pre\']}><code {...elementProps[\'code\']} className=\"language-bash\">brew tap buildkite/buildkite<br {...elementProps[\'br\']} />brew install --token=<span {...elementProps[\'span\']} className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br {...elementProps[\'br\']} />{\"\\n\"}<span {...elementProps[\'span\']} className=\"hljs-function\"><span {...elementProps[\'span\']} className=\"hljs-title\">function</span></span>() {\"{\"}<br {...elementProps[\'br\']} />{\"  \"}ENV=<span {...elementProps[\'span\']} className=\"hljs-string\">\"foo_bar\"</span><br {...elementProps[\'br\']} />{\"}\"}<br {...elementProps[\'br\']} /></code></pre>
     </div>
   );
 };
@@ -15846,11 +15982,12 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         React.createElement(\"br\", null),
-        \"  RUBY=blah\",
+        \"  \",
+        \"RUBY=blah\",
         React.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         React.createElement(\"br\", null)
       )
     ),
@@ -15893,12 +16030,13 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         React.createElement(\"br\", null),
-        \"  RUBY=\",
+        \"  \",
+        \"RUBY=\",
         props.rubycontent,
         React.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         React.createElement(\"br\", null)
       )
     ),
@@ -15972,6 +16110,7 @@ function MarkdownComponent(props) {
         ),
         \" buildkite-agent\",
         React.createElement(\"br\", null),
+        \"\\n\",
         React.createElement(
           \"span\",
           { className: \"hljs-function\" },
@@ -15982,16 +16121,17 @@ function MarkdownComponent(props) {
           )
         ),
         \"() \",
-        \'{\',
+        \"{\",
         React.createElement(\"br\", null),
-        \"  ENV=\",
+        \"  \",
+        \"ENV=\",
         React.createElement(
           \"span\",
           { className: \"hljs-string\" },
           \"\\\"foo_bar\\\"\"
         ),
         React.createElement(\"br\", null),
-        \'}\',
+        \"}\",
         React.createElement(\"br\", null)
       )
     )
@@ -16056,7 +16196,8 @@ exports[`Webpack loader with a webpack config object of \`{}\` for component exa
       () 
       {
       <br />
-        RUBY=blah
+        
+      RUBY=blah
       <br />
       }
       <br />
@@ -16091,7 +16232,8 @@ exports[`Webpack loader with a webpack config object of \`{}\` for component exa
       () 
       {
       <br />
-        RUBY=
+        
+      RUBY=
       <br />
       }
       <br />
@@ -16147,6 +16289,8 @@ exports[`Webpack loader with a webpack config object of \`{}\` for component exa
       </span>
        buildkite-agent
       <br />
+      
+      
       <span
         className="hljs-function">
         <span
@@ -16157,7 +16301,8 @@ exports[`Webpack loader with a webpack config object of \`{}\` for component exa
       () 
       {
       <br />
-        ENV=
+        
+      ENV=
       <span
         className="hljs-string">
         \"foo_bar\"
@@ -16194,23 +16339,22 @@ function MarkdownComponent(props) {
       <p>This is a basic Markdown template, with no interpolations going on.</p>
       <p>This should be</p>
       <ul>
-      <li>easy and;</li>
-      <li>predictable!</li>
+        <li>easy and;</li>
+        <li>predictable!</li>
       </ul>
       <h2>Here\'s a code snippet with no interpolations</h2>
       <pre><code className=\"language-bash\">npm install -g yarn<br /></code></pre>
       <h2>Here\'s a code snippet with things which shouldn\'t be treated as interpolations</h2>
-      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br />  RUBY=blah<br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br />{\"  \"}RUBY=blah<br />{\"}\"}<br /></code></pre>
       <h2>Here\'s a paragraph with a simple interpolation</h2>
       <p>There are {Object.keys(props).length} props being supplied to this component.</p>
       <h2>Here\'s a code snippet with a simple interpolation</h2>
-      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\'{\'}<br />  RUBY={props.rubycontent}<br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\"><span className=\"hljs-keyword\">function</span> <span className=\"hljs-function\"><span className=\"hljs-title\">rbenv</span></span>() {\"{\"}<br />{\"  \"}RUBY={props.rubycontent}<br />{\"}\"}<br /></code></pre>
       <h2>Here\'s an unhinted code snippet</h2>
       <pre><code><span className=\"hljs-keyword\">the</span> quick brown fox jumps over <span className=\"hljs-keyword\">the</span> lazy dog<br /></code></pre>
       <h2>Here\'s an unhinted snippet with no discernible language</h2>
       <pre><code>)<span className=\"hljs-comment\">()</span><span className=\"hljs-comment\">(()</span>)<br /></code></pre>
-      <pre><code className=\"language-bash\">brew tap buildkite/buildkite<br />brew install --token=<span className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br />
-      <span className=\"hljs-function\"><span className=\"hljs-title\">function</span></span>() {\'{\'}<br />  ENV=<span className=\"hljs-string\">\"foo_bar\"</span><br />{\'}\'}<br /></code></pre>
+      <pre><code className=\"language-bash\">brew tap buildkite/buildkite<br />brew install --token=<span className=\"hljs-string\">\'{props.token || \'INSERT-YOUR-AGENT-TOKEN-HERE\'}\'</span> buildkite-agent<br />{\"\\n\"}<span className=\"hljs-function\"><span className=\"hljs-title\">function</span></span>() {\"{\"}<br />{\"  \"}ENV=<span className=\"hljs-string\">\"foo_bar\"</span><br />{\"}\"}<br /></code></pre>
     </div>
   );
 };

--- a/src/formatters/import.js
+++ b/src/formatters/import.js
@@ -1,0 +1,1 @@
+export default (name, source) => `import ${name} from '${source}';\n`;

--- a/src/formatters/module.js
+++ b/src/formatters/module.js
@@ -1,0 +1,40 @@
+import DocChomp from 'doc-chomp';
+
+import { name, version } from '../../package.json';
+
+export default ({ passElementProps }, imports, statics, jsx) => {
+  let moduleText = DocChomp`
+    // Module generated from Markdown by ${name} v${version}
+    ${imports}
+    MarkdownComponent.propTypes = {
+      className: React.PropTypes.string,
+      style: React.PropTypes.object`;
+
+  if (passElementProps) {
+    moduleText += DocChomp(2)`,
+        elementProps: React.PropTypes.object
+      };
+
+      MarkdownComponent.defaultProps = {
+        elementProps: {}`;
+  }
+
+  moduleText += DocChomp(0)`
+    
+    };
+    ${statics}
+    function MarkdownComponent(props) {
+      const {className, style${passElementProps ? ', elementProps' : ''}} = props;
+
+      return (
+        <div className={className} style={style}>
+          ${jsx}
+        </div>
+      );
+    };
+
+    export default MarkdownComponent;
+    `;
+
+  return moduleText;
+};

--- a/src/formatters/static.js
+++ b/src/formatters/static.js
@@ -1,0 +1,11 @@
+import JSEsc from 'jsesc';
+
+const JSESC_CONFIG = {
+  compact: false,
+  indent: '  ',
+  wrap: true
+};
+
+const doEscape = (javascript) => JSEsc(javascript, JSESC_CONFIG);
+
+export default (name, value) => `\nMarkdownComponent[${doEscape(name)}] = ${doEscape(value)};\n`;

--- a/src/hex-to-alpha.js
+++ b/src/hex-to-alpha.js
@@ -1,0 +1,18 @@
+const empty = '';
+
+// Converts a hexadecimal string to an alphabetic string
+// for instance, "0" becomes "j", "f" becomes "y"
+export default (hexString, offsetChar = 'j') => (
+  hexString
+    .split(empty)
+    .reduce(
+      (accumulator, hexDigit) => (
+        accumulator + (
+          String.fromCharCode(
+            parseInt(hexDigit, 16) + offsetChar.charCodeAt(0)
+          )
+        )
+      ),
+      empty
+    )
+);

--- a/src/html-to-jsx.js
+++ b/src/html-to-jsx.js
@@ -1,0 +1,16 @@
+import HTMLtoJSX from 'htmltojsx';
+
+export default function htmlToJsx(html, indent = '') {
+  const jsxConverter = new HTMLtoJSX({ createClass: false });
+
+  let jsx = jsxConverter.convert(html);
+
+  if (jsxConverter.level === 1) {
+    // Remove the wrapping tags HTMLtoJSX adds, as we use our own!
+    jsx = jsx.replace(/(?:^<div>\n\s+|\n\s+<\/div>\n+$)/g, '');
+  }
+
+  return jsx
+    .replace(/\n\s{8}/g, `\n${indent}`) // Indent for pretty inspector output 🎉
+    .replace(/\n\s*$/g, '');            // Remove the trailing blank line
+}

--- a/src/string-replacement-cache.js
+++ b/src/string-replacement-cache.js
@@ -12,10 +12,6 @@ export default class StringReplacementCache {
   }
 
   load(body) {
-    if (this.loaded === true) {
-      throw new Error("StringReplacementCache: `load` called when cache was already loaded!");
-    }
-
     const processed = body
       .replace(this.expression, (match, ...values) => {
         const identityHash = hash(this.algorithm)
@@ -38,10 +34,6 @@ export default class StringReplacementCache {
   }
 
   unload(body) {
-    if (this.loaded === false) {
-      throw new Error("StringReplacementCache: `unload` called when cache was not loaded!");
-    }
-
     let processed = body;
 
     Object.keys(this._cache).forEach((identity) =>

--- a/src/string-replacement-cache.js
+++ b/src/string-replacement-cache.js
@@ -1,0 +1,65 @@
+import hash from 'sha.js';
+
+const noOpReplacer = (thing) => thing;
+
+export default class StringReplacementCache {
+  constructor(expression, outputReplacer = noOpReplacer, identityReplacer = noOpReplacer, algorithm = 'sha256') {
+    this.expression = expression;
+    this.outputReplacer = outputReplacer;
+    this.identityReplacer = identityReplacer;
+    this.algorithm = algorithm;
+    this._cache = {};
+  }
+
+  load(body) {
+    if (this.loaded === true) {
+      throw new Error("StringReplacementCache: `load` called when cache was already loaded!");
+    }
+
+    const processed = body
+      .replace(this.expression, (match, ...values) => {
+        const identityHash = hash(this.algorithm)
+          .update(match, 'utf-8')
+          .digest('hex');
+
+        const identity = this.identityReplacer(
+            identityHash,
+            match,
+            ...values
+          );
+
+        this._cache[identity] = this.outputReplacer(match, ...values);
+
+        return identity;
+      });
+
+    this.loaded = true;
+    return processed;
+  }
+
+  unload(body) {
+    if (this.loaded === false) {
+      throw new Error("StringReplacementCache: `unload` called when cache was not loaded!");
+    }
+
+    let processed = body;
+
+    Object.keys(this._cache).forEach((identity) =>
+      processed = processed
+        .replace(
+          new RegExp(
+            identity.replace(
+              /[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g,
+              '\\$&'
+            ),
+            'g'
+          ),
+          this._cache[identity]
+        )
+    );
+
+    this._cache = {};
+    this.loaded = false;
+    return processed;
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,6 +29,7 @@ module.exports = {
     ]
   },
   plugins: [
+    new webpack.DefinePlugin({ IN_BROWSER: true }), // gotta do this to make HTMLtoJSX not break in-browser
     new webpack.optimize.UglifyJsPlugin(),
     new ExtractTextPlugin("bundle.css", { allChunks: true })
   ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,7 +31,7 @@ acorn@^2.1.0, acorn@^2.4.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-2.7.0.tgz#ab6e7d9d886aaca8b085bc3312b79a198433f0e7"
 
-acorn@^3.0.0, acorn@^3.0.4:
+acorn@^3.0.0, acorn@^3.0.4, acorn@^3.1.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
@@ -171,6 +171,10 @@ assert@^1.1.1:
   resolved "https://registry.yarnpkg.com/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91"
   dependencies:
     util "0.10.3"
+
+ast-types@0.9.2:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.2.tgz#2cc19979d15c655108bf565323b8e7ee38751f6b"
 
 async-each@^1.0.0:
   version "1.0.1"
@@ -370,7 +374,7 @@ babel-helpers@^6.16.0:
     babel-runtime "^6.0.0"
     babel-template "^6.16.0"
 
-babel-jest, babel-jest@^17.0.2:
+babel-jest@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-17.0.2.tgz#8d51e0d03759713c331f108eb0b2eaa4c6efff74"
   dependencies:
@@ -757,10 +761,6 @@ babel-types@^6.15.0, babel-types@^6.16.0, babel-types@^6.18.0, babel-types@^6.19
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babel@^6.5.2:
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/babel/-/babel-6.5.2.tgz#59140607438270920047ff56f02b2d8630c2d129"
-
 babylon@^6.11.0, babylon@^6.13.0:
   version "6.14.1"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.14.1.tgz#956275fab72753ad9b3435d7afe58f8bf0a29815"
@@ -772,6 +772,10 @@ balanced-match@^0.4.1, balanced-match@^0.4.2:
 balanced-match@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.1.0.tgz#b504bd05869b39259dd0c5efc35d843176dccc4a"
+
+base62@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/base62/-/base62-1.1.2.tgz#22ced6a49913565bc0b8d9a11563a465c084124c"
 
 base64-js@^1.0.2:
   version "1.2.0"
@@ -825,6 +829,10 @@ braces@^1.8.2:
     expand-range "^1.8.1"
     preserve "^0.2.0"
     repeat-element "^1.1.2"
+
+"browser-request@>= 0.3.1 < 0.4.0":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/browser-request/-/browser-request-0.3.3.tgz#9ece5b5aca89a29932242e18bf933def9876cc17"
 
 browser-resolve@^1.11.2:
   version "1.11.2"
@@ -887,6 +895,10 @@ callsites@^2.0.0:
 camelcase@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
+
+camelcase@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
 
 camelcase@^3.0.0:
   version "3.0.0"
@@ -1056,7 +1068,7 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.8.1, commander@^2.9.0:
+commander@^2.5.0, commander@^2.8.1, commander@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
@@ -1065,6 +1077,20 @@ commander@^2.8.1, commander@^2.9.0:
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
+
+commoner@^0.10.1:
+  version "0.10.8"
+  resolved "https://registry.yarnpkg.com/commoner/-/commoner-0.10.8.tgz#34fc3672cd24393e8bb47e70caa0293811f4f2c5"
+  dependencies:
+    commander "^2.5.0"
+    detective "^4.3.1"
+    glob "^5.0.15"
+    graceful-fs "^4.1.2"
+    iconv-lite "^0.4.5"
+    mkdirp "^0.5.0"
+    private "^0.1.6"
+    q "^1.1.2"
+    recast "^0.11.17"
 
 compressible@~2.0.8:
   version "2.0.9"
@@ -1167,7 +1193,7 @@ css-color-names@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
 
-css-loader:
+css-loader@^0.26.0:
   version "0.26.0"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-0.26.0.tgz#160d378f5b8e0fd4ff6daf4f3580e2219b33025f"
   dependencies:
@@ -1252,7 +1278,7 @@ csso@~2.2.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.1.tgz#c9e37ef2490e64f6d1baa10fda852257082c25d3"
 
-"cssstyle@>= 0.2.36 < 0.3.0":
+"cssstyle@>= 0.2.21 < 0.3.0", "cssstyle@>= 0.2.36 < 0.3.0":
   version "0.2.37"
   resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-0.2.37.tgz#541097234cb2513c83ceed3acddc27ff27987d54"
   dependencies:
@@ -1336,6 +1362,13 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
+detective@^4.3.1:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/detective/-/detective-4.3.2.tgz#77697e2e7947ac3fe7c8e26a6d6f115235afa91c"
+  dependencies:
+    acorn "^3.1.0"
+    defined "^1.0.0"
+
 diff@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.1.0.tgz#9406c73a401e6c2b3ba901c5e2c44eb6a60c5385"
@@ -1353,9 +1386,37 @@ doctrine@^1.2.2:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
+dom-serializer@0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
+  dependencies:
+    domelementtype "~1.1.1"
+    entities "~1.1.1"
+
 domain-browser@^1.1.1:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.1.7.tgz#867aa4b093faa05f1de08c06f4d7b21fdf8698bc"
+
+domelementtype@^1.3.0, domelementtype@1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
+
+domelementtype@~1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
+
+domhandler@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.3.0.tgz#2de59a0822d5027fabff6f032c2b25a2a8abe738"
+  dependencies:
+    domelementtype "1"
+
+domutils@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"
@@ -1389,9 +1450,16 @@ enhanced-resolve@~0.9.0:
     memory-fs "^0.2.0"
     tapable "^0.1.8"
 
-entities@~1.1.1:
+entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
+
+envify@^3.0.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/envify/-/envify-3.4.1.tgz#d7122329e8df1688ba771b12501917c9ce5cbce8"
+  dependencies:
+    jstransform "^11.0.3"
+    through "~2.3.4"
 
 errno@^0.1.3, "errno@>=0.1.1 <0.2.0-0":
   version "0.1.4"
@@ -1538,6 +1606,10 @@ espree@^3.3.1:
     acorn "^4.0.1"
     acorn-jsx "^3.0.0"
 
+esprima-fb@^15001.1.0-dev-harmony-fb:
+  version "15001.1.0-dev-harmony-fb"
+  resolved "https://registry.yarnpkg.com/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz#30a947303c6b8d5e955bee2b99b1d233206a6901"
+
 esprima@^2.6.0, esprima@^2.7.1, esprima@2.7.x:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
@@ -1545,6 +1617,10 @@ esprima@^2.6.0, esprima@^2.7.1, esprima@2.7.x:
 esprima@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.0.0.tgz#53cf247acda77313e551c3aa2e73342d3fb4f7d9"
+
+esprima@~3.1.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.2.tgz#954b5d19321ca436092fa90f06d6798531fe8184"
 
 esrecurse@^4.1.0:
   version "4.1.0"
@@ -1694,6 +1770,16 @@ fb-watchman@^1.8.0, fb-watchman@^1.9.0:
   resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-1.9.0.tgz#6f268f1f347a6b3c875d1e89da7e1ed79adfc0ec"
   dependencies:
     bser "^1.0.2"
+
+fbjs@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.6.1.tgz#9636b7705f5ba9684d44b72f78321254afc860f7"
+  dependencies:
+    core-js "^1.0.0"
+    loose-envify "^1.0.0"
+    promise "^7.0.3"
+    ua-parser-js "^0.7.9"
+    whatwg-fetch "^0.9.0"
 
 fbjs@^0.8.4:
   version "0.8.6"
@@ -2027,6 +2113,25 @@ html-encoding-sniffer@^1.0.1:
   dependencies:
     whatwg-encoding "^1.0.1"
 
+"htmlparser2@>= 3.7.3 < 4.0.0":
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
+  dependencies:
+    domelementtype "^1.3.0"
+    domhandler "^2.3.0"
+    domutils "^1.5.1"
+    entities "^1.1.1"
+    inherits "^2.0.1"
+    readable-stream "^2.0.2"
+
+"htmltojsx@https://github.com/reactjs/react-magic#e63dabeefb87d4ce1e74ac2ddb73b0164c344219":
+  version "0.2.6-dev"
+  resolved "https://github.com/reactjs/react-magic#e63dabeefb87d4ce1e74ac2ddb73b0164c344219"
+  dependencies:
+    jsdom-no-contextify "~3.1.0"
+    react "~0.14.6"
+    yargs "~4.6.0"
+
 http-browserify@^1.3.2:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/http-browserify/-/http-browserify-1.7.0.tgz#33795ade72df88acfbfd36773cefeda764735b20"
@@ -2070,7 +2175,7 @@ https-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.0.tgz#b3ffdfe734b2a3d4a9efd58e8654c91fce86eafd"
 
-iconv-lite@^0.4.13, iconv-lite@~0.4.13:
+iconv-lite@^0.4.13, iconv-lite@^0.4.5, iconv-lite@~0.4.13:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
 
@@ -2425,12 +2530,6 @@ istanbul@^0.4.5:
     which "^1.1.1"
     wordwrap "^1.0.0"
 
-jest:
-  version "17.0.3"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-17.0.3.tgz#89c43b30b0aaad42462e9ea701352dacbad4a354"
-  dependencies:
-    jest-cli "^17.0.3"
-
 jest-changed-files@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-17.0.2.tgz#f5657758736996f590a51b87e5c9369d904ba7b7"
@@ -2606,6 +2705,12 @@ jest-util@^17.0.2:
     jest-mock "^17.0.2"
     mkdirp "^0.5.1"
 
+jest@^17.0.3:
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-17.0.3.tgz#89c43b30b0aaad42462e9ea701352dacbad4a354"
+  dependencies:
+    jest-cli "^17.0.3"
+
 jodid25519@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/jodid25519/-/jodid25519-1.0.2.tgz#06d4912255093419477d425633606e0e90782967"
@@ -2637,6 +2742,20 @@ js-yaml@~3.6.1:
 jsbn@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.0.tgz#650987da0dd74f4ebf5a11377a2aa2d273e97dfd"
+
+jsdom-no-contextify@~3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/jsdom-no-contextify/-/jsdom-no-contextify-3.1.0.tgz#0d8beaf610c2ff23894f54dfa7f89dd22fd0f7ab"
+  dependencies:
+    browser-request ">= 0.3.1 < 0.4.0"
+    cssom ">= 0.3.0 < 0.4.0"
+    cssstyle ">= 0.2.21 < 0.3.0"
+    htmlparser2 ">= 3.7.3 < 4.0.0"
+    nwmatcher ">= 1.3.4 < 2.0.0"
+    parse5 ">= 1.3.1 < 2.0.0"
+    request ">= 2.44.0 < 3.0.0"
+    xml-name-validator "^1.0.0"
+    xmlhttprequest ">= 1.6.0 < 2.0.0"
 
 jsdom@^9.8.1:
   version "9.8.3"
@@ -2717,6 +2836,16 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.3.6"
 
+jstransform@^11.0.3:
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/jstransform/-/jstransform-11.0.3.tgz#09a78993e0ae4d4ef4487f6155a91f6190cb4223"
+  dependencies:
+    base62 "^1.1.0"
+    commoner "^0.10.1"
+    esprima-fb "^15001.1.0-dev-harmony-fb"
+    object-assign "^2.0.0"
+    source-map "^0.4.2"
+
 jsx-ast-utils@^1.3.3:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.3.4.tgz#0257ed1cc4b1e65b39d7d9940f9fb4f20f7ba0a9"
@@ -2757,7 +2886,7 @@ literal-toast@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/literal-toast/-/literal-toast-1.0.0.tgz#7c79c30a32db5325ae4c680af1658240f4c9dbbe"
 
-load-json-file@^1.0.0:
+load-json-file@^1.0.0, load-json-file@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
   dependencies:
@@ -2818,7 +2947,7 @@ lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
 
-lodash.assign@^4.2.0:
+lodash.assign@^4.0.3, lodash.assign@^4.0.6, lodash.assign@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
 
@@ -2881,7 +3010,7 @@ makeerror@1.0.x:
   dependencies:
     tmpl "1.0.x"
 
-markdown-it:
+markdown-it@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-8.1.0.tgz#38902d4e7bac2260c073eb67be623211fbb2c2e3"
   dependencies:
@@ -2890,10 +3019,6 @@ markdown-it:
     linkify-it "^2.0.0"
     mdurl "^1.0.1"
     uc.micro "^1.0.3"
-
-markdown-it-regexp@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/markdown-it-regexp/-/markdown-it-regexp-0.4.0.tgz#d64d713eecec55ce4cfdeb321750ecc099e2c2dc"
 
 marked-terminal@^1.6.2:
   version "1.7.0"
@@ -3161,13 +3286,17 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-"nwmatcher@>= 1.3.7 < 2.0.0":
+"nwmatcher@>= 1.3.4 < 2.0.0", "nwmatcher@>= 1.3.7 < 2.0.0":
   version "1.3.9"
   resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.3.9.tgz#8bab486ff7fa3dfd086656bbe8b17116d3692d2a"
 
 oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
+
+object-assign@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-2.1.1.tgz#43c36e5d569ff8e4816c4efa8be02d26967c18aa"
 
 object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.0"
@@ -3279,7 +3408,7 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
-parse5@^1.5.1:
+parse5@^1.5.1, "parse5@>= 1.3.1 < 2.0.0":
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
 
@@ -3338,6 +3467,15 @@ pinkie-promise@^2.0.0:
 pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
+
+pkg-conf@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/pkg-conf/-/pkg-conf-1.1.3.tgz#378e56d6fd13e88bfb6f4a25df7a83faabddba5b"
+  dependencies:
+    find-up "^1.0.0"
+    load-json-file "^1.1.0"
+    object-assign "^4.0.1"
+    symbol "^0.2.1"
 
 pkg-dir@^1.0.0:
   version "1.0.0"
@@ -3616,7 +3754,7 @@ progress@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
 
-promise@^7.1.1:
+promise@^7.0.3, promise@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
   dependencies:
@@ -3708,6 +3846,13 @@ react@^15.3.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
 
+react@~0.14.6:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/react/-/react-0.14.8.tgz#078dfa454d4745bcc54a9726311c2bf272c23684"
+  dependencies:
+    envify "^3.0.0"
+    fbjs "^0.6.1"
+
 read-pkg-up@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
@@ -3783,6 +3928,15 @@ readline2@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     mute-stream "0.0.5"
+
+recast@^0.11.17:
+  version "0.11.17"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.11.17.tgz#67e829df49ef8ea822381cc516d305411e60bad8"
+  dependencies:
+    ast-types "0.9.2"
+    esprima "~3.1.0"
+    private "~0.1.5"
+    source-map "~0.5.0"
 
 rechoir@^0.6.2:
   version "0.6.2"
@@ -3865,7 +4019,7 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@^2.55.0, request@^2.75.0:
+request@^2.55.0, request@^2.75.0, "request@>= 2.44.0 < 3.0.0":
   version "2.79.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
   dependencies:
@@ -4094,13 +4248,13 @@ source-map-support@^0.4.2:
   dependencies:
     source-map "^0.5.3"
 
-source-map@^0.4.4, source-map@~0.4.1:
+source-map@^0.4.2, source-map@^0.4.4, source-map@~0.4.1:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.3:
+source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.0, source-map@~0.5.1, source-map@~0.5.3:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
@@ -4235,6 +4389,10 @@ svgo@^0.7.0:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.1.4.tgz#02b279348d337debc39694c5c95f882d448a312a"
 
+symbol@^0.2.1:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/symbol/-/symbol-0.2.3.tgz#3b9873b8a901e47c6efe21526a3ac372ef28bbc7"
+
 table@^3.7.8:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/table/-/table-3.8.3.tgz#2bbc542f0fda9861a755d3947fefd8b3f513855f"
@@ -4289,7 +4447,7 @@ throat@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-3.0.0.tgz#e7c64c867cbb3845f10877642f7b60055b8ec0d6"
 
-through@^2.3.6:
+through@^2.3.6, through@~2.3.4:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
@@ -4578,6 +4736,10 @@ whatwg-encoding@^1.0.1:
   dependencies:
     iconv-lite "0.4.13"
 
+whatwg-fetch@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz#0e3684c6cb9995b43efc9df03e4c365d95fd9cc0"
+
 whatwg-fetch@>=0.10.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.1.tgz#078b9461bbe91cea73cbce8bb122a05f9e92b772"
@@ -4652,9 +4814,17 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
+xml-name-validator@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-1.0.0.tgz#dcf82ee092322951ef8cc1ba596c9cbfd14a83f1"
+
 "xml-name-validator@>= 2.0.1 < 3.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
+
+"xmlhttprequest@>= 1.6.0 < 2.0.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz#67fe075c5c24fef39f9d65f5f7b7fe75171968fc"
 
 xtend@^4.0.0, "xtend@>=4.0.0 <4.1.0-0":
   version "4.0.1"
@@ -4663,6 +4833,13 @@ xtend@^4.0.0, "xtend@>=4.0.0 <4.1.0-0":
 y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
+
+yargs-parser@^2.4.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-2.4.1.tgz#85568de3cf150ff49fa51825f03a8c880ddcc5c4"
+  dependencies:
+    camelcase "^3.0.0"
+    lodash.assign "^4.0.6"
 
 yargs-parser@^4.1.0:
   version "4.1.0"
@@ -4697,4 +4874,21 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+yargs@~4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-4.6.0.tgz#cb4050c0159bfb6bb649c0f4af550526a84619dc"
+  dependencies:
+    camelcase "^2.0.1"
+    cliui "^3.2.0"
+    decamelize "^1.1.1"
+    lodash.assign "^4.0.3"
+    os-locale "^1.4.0"
+    pkg-conf "^1.1.2"
+    read-pkg-up "^1.0.1"
+    require-main-filename "^1.0.1"
+    string-width "^1.0.1"
+    window-size "^0.2.0"
+    y18n "^3.2.1"
+    yargs-parser "^2.4.0"
 


### PR DESCRIPTION
- simplifies custom code, and replaces it with stuff that does a better job of escaping already!
- obviates the weird custom selectors and plugin we were using to work around the Markdown parser’s limitations
- refactor a bit to facilitate future changes!